### PR TITLE
feat: add Ley 25.326 (Protección de Datos Personales)

### DIFF
--- a/data/25326/PROTECCION DE LOS DATOS.html
+++ b/data/25326/PROTECCION DE LOS DATOS.html
@@ -1,0 +1,293 @@
+
+<!-- saved from url=(0084)https://servicios.infoleg.gob.ar/infolegInternet/anexos/60000-64999/64790/texact.htm -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async="" src="./PROTECCION DE LOS DATOS_files/analytics.js"></script><script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-80126894-1', 'auto');
+  ga('send', 'pageview');
+</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async="" src="./PROTECCION DE LOS DATOS_files/js"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-8TJE6KQ2XX');
+</script>
+
+
+<meta name="Generator" content="Microsoft Word 97">
+<title>PROTECCION DE LOS DATOS</title>
+<meta name="Template" content="C:\Archivos de programa\Office97\Office\html.dot">
+<link rel="StyleSheet" href="./PROTECCION DE LOS DATOS_files/style_normas.css" type="text/css"></head>
+<body><div id="wrap"><header id="branding" role="banner">    <div id="encabezado_norma">	<img src="./PROTECCION DE LOS DATOS_files/left.png" width="100%" border="0" usemap="#Map" style="max-width: 740px;">        <map name="Map">            <area shape="rect" coords="11,4,192,30" href="https://www.infoleg.gob.ar/" target="_blank" alt="inicio sitio infoleg">            <area shape="rect" coords="395,6,614,28" href="https://www.jus.gob.ar/" target="_blank" alt="MInisterio de Justicia">        </map><br>    </div></header><div id="cleaner"></div></div>
+
+<b><p align="JUSTIFY">PROTECCION DE LOS DATOS PERSONALES</p>
+<p align="JUSTIFY">Ley 25.326</p>
+<p align="JUSTIFY">Disposiciones Generales. Principios generales relativos a la protección de datos. Derechos de los titulares de datos. Usuarios y responsables de archivos, registros y bancos de datos. Control. Sanciones. Acción de protección de los datos personales.</p>
+</b><p align="JUSTIFY">Sancionada: Octubre 4 de 2000.</p>
+<p align="JUSTIFY">Promulgada Parcialmente: Octubre 30 de 2000.</p>
+<p><a href="https://servicios.infoleg.gob.ar/infolegInternet/anexos/60000-64999/64790/texact.htm#1"><b>Ver Antecedentes Normativos</b></a></p>
+<p align="CENTER">El Senado y Cámara de Diputados de la Nación Argentina reunidos en Congreso, etc. sancionan con fuerza de Ley:</p>
+<p align="CENTER">Ley de Protección de los Datos Personales</p>
+<p align="CENTER">Capítulo I</p>
+<p align="CENTER">Disposiciones Generales</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 1° </b>— (Objeto).</p>
+<p align="JUSTIFY">La presente ley tiene por objeto la protección integral de los datos personales asentados en archivos, registros, bancos de datos, u otros medios técnicos de tratamiento de datos, sean éstos públicos, o privados destinados a dar informes, para garantizar el derecho al honor y a la intimidad de las personas, así como también el acceso a la información que sobre las mismas se registre, de conformidad a lo establecido en el artículo 43, párrafo tercero de la Constitución Nacional. </p>
+<p align="JUSTIFY">Las disposiciones de la presente ley también serán aplicables, en cuanto resulte pertinente, a los datos relativos a personas de existencia ideal.</p>
+<p align="JUSTIFY">En ningún caso se podrán afectar la base de datos ni las fuentes de información periodísticas.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 2° </b>— (Definiciones). </p>
+<p align="JUSTIFY">A los fines de la presente ley se entiende por:</p>
+<p align="JUSTIFY">— Datos personales: Información de cualquier tipo referida a personas físicas o de existencia ideal determinadas o determinables.</p>
+<p align="JUSTIFY">— Datos sensibles: Datos personales que revelan origen racial y étnico, opiniones políticas, convicciones religiosas, filosóficas o morales, afiliación sindical e información referente a la salud o a la vida sexual.</p>
+<p align="JUSTIFY">— Archivo, registro, base o banco de datos: Indistintamente, designan al conjunto organizado de datos personales que sean objeto de tratamiento o procesamiento, electrónico o no, cualquiera que fuere la modalidad de su formación, almacenamiento, organización o acceso.</p>
+<p align="JUSTIFY">— Tratamiento de datos: Operaciones y procedimientos sistemáticos, electrónicos o no, que permitan la recolección, conservación, ordenación, almacenamiento, modificación, relacionamiento, evaluación, bloqueo, destrucción, y en general el procesamiento de datos personales, así como también su cesión a terceros a través de comunicaciones, consultas, interconexiones o transferencias.</p>
+<p align="JUSTIFY">— Responsable de archivo, registro, base o banco de datos: Persona física o de existencia ideal pública o privada, que es titular de un archivo, registro, base o banco de datos.</p>
+<p align="JUSTIFY">— Datos informatizados: Los datos personales sometidos al tratamiento o procesamiento electrónico o automatizado.</p>
+<p align="JUSTIFY">— Titular de los datos: Toda persona física o persona de existencia ideal con domicilio legal o delegaciones o sucursales en el país, cuyos datos sean objeto del tratamiento al que se refiere la presente ley.</p>
+<p align="JUSTIFY">— Usuario de datos: Toda persona, pública o privada que realice a su arbitrio el tratamiento de datos, ya sea en archivos, registros o bancos de datos propios o a través de conexión con los mismos.</p>
+<p align="JUSTIFY">— Disociación de datos: Todo tratamiento de datos personales de manera que la información obtenida no pueda asociarse a persona determinada o determinable.</p>
+<p align="CENTER">Capítulo II</p>
+<p align="CENTER">Principios generales relativos a la protección de datos</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 3° </b>— (Archivos de datos – Licitud).</p>
+<p align="JUSTIFY">La formación de archivos de datos será lícita cuando se encuentren debidamente inscriptos, observando en su operación los principios que establece la presente ley y las reglamentaciones que se dicten en su consecuencia.</p>
+<p align="JUSTIFY">Los archivos de datos no pueden tener finalidades contrarias a las leyes o a la moral pública.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 4° </b>— (Calidad de los datos). </p>
+<p align="JUSTIFY">1. Los datos personales que se recojan a los efectos de su tratamiento deben ser ciertos, adecuados, pertinentes y no excesivos en relación al ámbito y finalidad para los que se hubieren obtenido. </p>
+<p align="JUSTIFY">2. La recolección de datos no puede hacerse por medios desleales, fraudulentos o en forma contraria a las disposiciones de la presente ley.</p>
+<p align="JUSTIFY">3. Los datos objeto de tratamiento no pueden ser utilizados para finalidades distintas o incompatibles con aquellas que motivaron su obtención.</p>
+<p align="JUSTIFY">4. Los datos deben ser exactos y actualizarse en el caso de que ello fuere necesario.</p>
+<p align="JUSTIFY">5. Los datos total o parcialmente inexactos, o que sean incompletos, deben ser suprimidos y sustituidos, o en su caso completados, por el responsable del archivo o base de datos cuando se tenga conocimiento de la inexactitud o carácter incompleto de la información de que se trate, sin perjuicio de los derechos del titular establecidos en el artículo 16 de la presente ley.</p>
+<p align="JUSTIFY">6. Los datos deben ser almacenados de modo que permitan el ejercicio del derecho de acceso de su titular.</p>
+<p align="JUSTIFY">7. Los datos deben ser destruidos cuando hayan dejado de ser necesarios o pertinentes a los fines para los cuales hubiesen sido recolectados.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 5° </b>— (Consentimiento).</p>
+<p align="JUSTIFY">1. El tratamiento de datos personales es ilícito cuando el titular no hubiere prestado su consentimiento libre, expreso e informado, el que deberá constar por escrito, o por otro medio que permita se le equipare, de acuerdo a las circunstancias.</p>
+<p align="JUSTIFY">El referido consentimiento prestado con otras declaraciones, deberá figurar en forma expresa y destacada, previa notificación al requerido de datos, de la información descrita en el artículo 6° de la presente ley.</p>
+<p align="JUSTIFY">2. No será necesario el consentimiento cuando: </p>
+<p align="JUSTIFY">a) Los datos se obtengan de fuentes de acceso público irrestricto;</p>
+<p align="JUSTIFY">b) Se recaben para el ejercicio de funciones propias de los poderes del Estado o en virtud de una obligación legal;</p>
+<p align="JUSTIFY">c) Se trate de listados cuyos datos se limiten a nombre, documento nacional de identidad, identificación tributaria o previsional, ocupación, fecha de nacimiento y domicilio;</p>
+<p align="JUSTIFY">d) Deriven de una relación contractual, científica o profesional del titular de los datos, y resulten necesarios para su desarrollo o cumplimiento;</p>
+<p align="JUSTIFY">e) Se trate de las operaciones que realicen las entidades financieras y de las informaciones que reciban de sus clientes conforme las disposiciones del artículo 39 de la Ley 21.526.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 6° </b>— (Información). </p>
+<p align="JUSTIFY">Cuando se recaben datos personales se deberá informar previamente a sus titulares en forma expresa y clara:</p>
+<p align="JUSTIFY">a) La finalidad para la que serán tratados y quiénes pueden ser sus destinatarios o clase de destinatarios;</p>
+<p align="JUSTIFY">b) La existencia del archivo, registro, banco de datos, electrónico o de cualquier otro tipo, de que se trate y la identidad y domicilio de su responsable;</p>
+<p align="JUSTIFY">c) El carácter obligatorio o facultativo de las respuestas al cuestionario que se le proponga, en especial en cuanto a los datos referidos en el artículo siguiente;</p>
+<p align="JUSTIFY">d) Las consecuencias de proporcionar los datos, de la negativa a hacerlo o de la inexactitud de los mismos;</p>
+<p align="JUSTIFY">e) La posibilidad del interesado de ejercer los derechos de acceso, rectificación y supresión de los datos.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 7° </b>— (Categoría de datos).</p>
+<p align="JUSTIFY">1. Ninguna persona puede ser obligada a proporcionar datos sensibles.</p>
+<p align="JUSTIFY">2. Los datos sensibles sólo pueden ser recolectados y objeto de tratamiento cuando medien razones de interés general autorizadas por ley. También podrán ser tratados con finalidades estadísticas o científicas cuando no puedan ser identificados sus titulares.</p>
+<p align="JUSTIFY">3. Queda prohibida la formación de archivos, bancos o registros que almacenen información que directa o indirectamente revele datos sensibles. Sin perjuicio de ello, la Iglesia Católica, las asociaciones religiosas y las organizaciones políticas y sindicales podrán llevar un registro de sus miembros.</p>
+<p align="JUSTIFY">4. Los datos relativos a antecedentes penales o contravencionales sólo pueden ser objeto de tratamiento por parte de las autoridades públicas competentes, en el marco de las leyes y reglamentaciones respectivas.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 8° </b>— (Datos relativos a la salud).</p>
+<p align="JUSTIFY">Los establecimientos sanitarios públicos o privados y los profesionales vinculados a las ciencias de la salud pueden recolectar y tratar los datos personales relativos a la salud física o mental de los pacientes que acudan a los mismos o que estén o hubieren estado bajo tratamiento de aquéllos, respetando los principios del secreto profesional. </p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 9° </b>— (Seguridad de los datos).</p>
+<p align="JUSTIFY">1. El responsable o usuario del archivo de datos debe adoptar las medidas técnicas y organizativas que resulten necesarias para garantizar la seguridad y confidencialidad de los datos personales, de modo de evitar su adulteración, pérdida, consulta o tratamiento no autorizado, y que permitan detectar desviaciones, intencionales o no, de información, ya sea que los riesgos provengan de la acción humana o del medio técnico utilizado.</p>
+<p align="JUSTIFY">2. Queda prohibido registrar datos personales en archivos, registros o bancos que no reúnan condiciones técnicas de integridad y seguridad.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 10. </b>— (Deber de confidencialidad).</p>
+<p align="JUSTIFY">1. El responsable y las personas que intervengan en cualquier fase del tratamiento de datos personales están obligados al secreto profesional respecto de los mismos. Tal obligación subsistirá aun después de finalizada su relación con el titular del archivo de datos.</p>
+<p align="JUSTIFY">2. El obligado podrá ser relevado del deber de secreto por resolución judicial y cuando medien razones fundadas relativas a la seguridad pública, la defensa nacional o la salud pública.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 11. </b>— (Cesión).</p>
+<p align="JUSTIFY">1. Los datos personales objeto de tratamiento sólo pueden ser cedidos para el cumplimiento de los fines directamente relacionados con el interés legítimo del cedente y del cesionario y con el previo consentimiento del titular de los datos, al que se le debe informar sobre la finalidad de la cesión e identificar al cesionario o los elementos que permitan hacerlo.</p>
+<p align="JUSTIFY">2. El consentimiento para la cesión es revocable.</p>
+<p align="JUSTIFY">3. El consentimiento no es exigido cuando:</p>
+<p align="JUSTIFY">a) Así lo disponga una ley;</p>
+<p align="JUSTIFY">b) En los supuestos previstos en el artículo 5° inciso 2;</p>
+<p align="JUSTIFY">c) Se realice entre dependencias de los órganos del Estado en forma directa, en la medida del cumplimiento de sus respectivas competencias;</p>
+<p align="JUSTIFY">d) Se trate de datos personales relativos a la salud, y sea necesario por razones de salud pública, de emergencia o para la realización de estudios epidemiológicos, en tanto se preserve la identidad de los titulares de los datos mediante mecanismos de disociación adecuados;</p>
+<p align="JUSTIFY">e) Se hubiera aplicado un procedimiento de disociación de la información, de modo que los titulares de los datos sean inidentificables.</p>
+<p align="JUSTIFY">4. El cesionario quedará sujeto a las mismas obligaciones legales y reglamentarias del cedente y éste responderá solidaria y conjuntamente por la observancia de las mismas ante el organismo de control y el titular de los datos de que se trate.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 12. </b>— (Transferencia internacional).</p>
+<p align="JUSTIFY">1. Es prohibida la transferencia de datos personales de cualquier tipo con países u organismos internacionales o supranacionales, que no propocionen niveles de protección adecuados.</p>
+<p align="JUSTIFY">2. La prohibición no regirá en los siguientes supuestos:</p>
+<p align="JUSTIFY">a) Colaboración judicial internacional;</p>
+<p align="JUSTIFY">b) Intercambio de datos de carácter médico, cuando así lo exija el tratamiento del afectado, o una investigación epidemiológica, en tanto se realice en los términos del inciso e) del artículo anterior; </p>
+<p align="JUSTIFY">c) Transferencias bancarias o bursátiles, en lo relativo a las transacciones respectivas y conforme la legislación que les resulte aplicable;</p>
+<p align="JUSTIFY">d) Cuando la transferencia se hubiera acordado en el marco de tratados internacionales en los cuales la República Argentina sea parte;</p>
+<p align="JUSTIFY">e) Cuando la transferencia tenga por objeto la cooperación internacional entre organismos de inteligencia para la lucha contra el crimen organizado, el terrorismo y el narcotráfico.</p>
+<p align="CENTER">Capítulo III</p>
+<p align="CENTER">Derechos de los titulares de datos</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 13. </b>— (Derecho de Información).</p>
+<p align="JUSTIFY">Toda persona puede solicitar información al organismo de control relativa a la existencia de archivos, registros, bases o bancos de datos personales, sus finalidades y la identidad de sus responsables.</p>
+<p align="JUSTIFY">El registro que se lleve al efecto será de consulta pública y gratuita.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 14. </b>— (Derecho de acceso).</p>
+<p align="JUSTIFY">1. El titular de los datos, previa acreditación de su identidad, tiene derecho a solicitar y obtener información de sus datos personales incluidos en los bancos de datos públicos, o privados destinados a proveer informes.</p>
+<p align="JUSTIFY">2. El responsable o usuario debe proporcionar la información solicitada dentro de los diez días corridos de haber sido intimado fehacientemente. </p>
+<p align="JUSTIFY">Vencido el plazo sin que se satisfaga el pedido, o si evacuado el informe, éste se estimara insuficiente, quedará expedita la acción de protección de los datos personales o de hábeas data prevista en esta ley.</p>
+<p align="JUSTIFY">3. El derecho de acceso a que se refiere este artículo sólo puede ser ejercido en forma gratuita a intervalos no inferiores a seis meses, salvo que se acredite un interés legítimo al efecto.</p>
+<p align="JUSTIFY">4. El ejercicio del derecho al cual se refiere este artículo en el caso de datos de personas fallecidas le corresponderá a sus sucesores universales. </p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 15. </b>— (Contenido de la información).</p>
+<p align="JUSTIFY">1. La información debe ser suministrada en forma clara, exenta de codificaciones y en su caso acompañada de una explicación, en lenguaje accesible al conocimiento medio de la población, de los términos que se utilicen.</p>
+<p align="JUSTIFY">2. La información debe ser amplia y versar sobre la totalidad del registro perteneciente al titular, aun cuando el requerimiento sólo comprenda un aspecto de los datos personales. En ningún caso el informe podrá revelar datos pertenecientes a terceros, aun cuando se vinculen con el interesado. </p>
+<p align="JUSTIFY">3. La información, a opción del titular, podrá suministrarse por escrito, por medios electrónicos, telefónicos, de imagen, u otro idóneo a tal fin.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 16. </b>— (Derecho de rectificación, actualización o supresión).</p>
+<p align="JUSTIFY">1. Toda persona tiene derecho a que sean rectificados, actualizados y, cuando corresponda, suprimidos o sometidos a confidencialidad los datos personales de los que sea titular, que estén incluidos en un banco de datos.</p>
+<p align="JUSTIFY">2. El responsable o usuario del banco de datos, debe proceder a la rectificación, supresión o actualización de los datos personales del afectado, realizando las operaciones necesarias a tal fin en el plazo máximo de cinco días hábiles de recibido el reclamo del titular de los datos o advertido el error o falsedad.</p>
+<p align="JUSTIFY">3. El incumplimiento de esta obligación dentro del término acordado en el inciso precedente, habilitará al interesado a promover sin más la acción de protección de los datos personales o de hábeas data prevista en la presente ley.</p>
+<p align="JUSTIFY">4. En el supuesto de cesión, o transferencia de datos, el responsable o usuario del banco de datos debe notificar la rectificación o supresión al cesionario dentro del quinto día hábil de efectuado el tratamiento del dato.</p>
+<p align="JUSTIFY">5. La supresión no procede cuando pudiese causar perjuicios a derechos o intereses legítimos de terceros, o cuando existiera una obligación legal de conservar los datos.</p>
+<p align="JUSTIFY">6. Durante el proceso de verificación y rectificación del error o falsedad de la información que se trate, el responsable o usuario del banco de datos deberá o bien bloquear el archivo, o consignar al proveer información relativa al mismo la circunstancia de que se encuentra sometida a revisión.</p>
+<p align="JUSTIFY">7. Los datos personales deben ser conservados durante los plazos previstos en las disposiciones aplicables o en su caso, en las contractuales entre el responsable o usuario del banco de datos y el titular de los datos.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 17. </b>— (Excepciones).</p>
+<p align="JUSTIFY">1. Los responsables o usuarios de bancos de datos públicos pueden, mediante decisión fundada, denegar el acceso, rectificación o la supresión en función de la protección de la defensa de la Nación, del orden y la seguridad públicos, o de la protección de los derechos e intereses de terceros.</p>
+<p align="JUSTIFY">2. La información sobre datos personales también puede ser denegada por los responsables o usuarios de bancos de datos públicos, cuando de tal modo se pudieran obstaculizar actuaciones judiciales o administrativas en curso vinculadas a la investigación sobre el cumplimiento de obligaciones tributarias o previsionales, el desarrollo de funciones de control de la salud y del medio ambiente, la investigación de delitos penales y la verificación de infracciones administrativas. La resolución que así lo disponga debe ser fundada y notificada al afectado.</p>
+<p align="JUSTIFY">3. Sin perjuicio de lo establecido en los incisos anteriores, se deberá brindar acceso a los registros en cuestión en la oportunidad en que el afectado tenga que ejercer su derecho de defensa.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 18. </b>— (Comisiones legislativas).</p>
+<p align="JUSTIFY">Las Comisiones de Defensa Nacional y la Comisión Bicameral de Fiscalización de los Organos y Actividades de Seguridad Interior e Inteligencia del Congreso de la Nación y la Comisión de Seguridad Interior de la Cámara de Diputados de la Nación, o las que las sustituyan, tendrán acceso a los archivos o bancos de datos referidos en el artículo 23 inciso 2 por razones fundadas y en aquellos aspectos que constituyan materia de competencia de tales Comisiones.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 19. </b>— (Gratuidad).</p>
+<p align="JUSTIFY">La rectificación, actualización o supresión de datos personales inexactos o incompletos que obren en registros públicos o privados se efectuará sin cargo alguno para el interesado.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 20. </b>— (Impugnación de valoraciones personales).</p>
+<p align="JUSTIFY">1. Las decisiones judiciales o los actos administrativos que impliquen apreciación o valoración de conductas humanas, no podrán tener como único fundamento el resultado del tratamiento informatizado de datos personales que suministren una definición del perfil o personalidad del interesado. </p>
+<p align="JUSTIFY">2. Los actos que resulten contrarios a la disposición precedente serán insanablemente nulos. </p>
+<p align="CENTER">Capítulo IV</p>
+<p align="CENTER">Usuarios y responsables de archivos, registros y bancos de datos</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 21. </b>— (Registro de archivos de datos. Inscripción).</p>
+<p align="JUSTIFY">1. Todo archivo, registro, base o banco de datos público, y privado destinado a proporcionar informes debe inscribirse en el Registro que al efecto habilite el organismo de control.</p>
+<p align="JUSTIFY">2. El registro de archivos de datos debe comprender como mínimo la siguiente información: </p>
+<p align="JUSTIFY">a) Nombre y domicilio del responsable;</p>
+<p align="JUSTIFY">b) Características y finalidad del archivo;</p>
+<p align="JUSTIFY">c) Naturaleza de los datos personales contenidos en cada archivo;</p>
+<p align="JUSTIFY">d) Forma de recolección y actualización de datos;</p>
+<p align="JUSTIFY">e) Destino de los datos y personas físicas o de existencia ideal a las que pueden ser transmitidos;</p>
+<p align="JUSTIFY">f) Modo de interrelacionar la información registrada;</p>
+<p align="JUSTIFY">g) Medios utilizados para garantizar la seguridad de los datos, debiendo detallar la categoría de personas con acceso al tratamiento de la información;</p>
+<p align="JUSTIFY">h) Tiempo de conservación de los datos;</p>
+<p align="JUSTIFY">i) Forma y condiciones en que las personas pueden acceder a los datos referidos a ellas y los procedimientos a realizar para la rectificación o actualización de los datos.</p>
+<p align="JUSTIFY">3) Ningún usuario de datos podrá poseer datos personales de naturaleza distinta a los declarados en el registro.</p>
+<p align="JUSTIFY">El incumplimiento de estos requisitos dará lugar a las sanciones administrativas previstas en el capítulo VI de la presente ley.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 22. </b>— (Archivos, registros o bancos de datos públicos).</p>
+<p align="JUSTIFY">1. Las normas sobre creación, modificación o supresión de archivos, registros o bancos de datos pertenecientes a organismos públicos deben hacerse por medio de disposición general publicada en el Boletín Oficial de la Nación o diario oficial.</p>
+<p align="JUSTIFY">2. Las disposiciones respectivas, deben indicar:</p>
+<p align="JUSTIFY">a) Características y finalidad del archivo;</p>
+<p align="JUSTIFY">b) Personas respecto de las cuales se pretenda obtener datos y el carácter facultativo u obligatorio de su suministro por parte de aquéllas;</p>
+<p align="JUSTIFY">c) Procedimiento de obtención y actualización de los datos;</p>
+<p align="JUSTIFY">d) Estructura básica del archivo, informatizado o no, y la descripción de la naturaleza de los datos personales que contendrán;</p>
+<p align="JUSTIFY">e) Las cesiones, transferencias o interconexiones previstas;</p>
+<p align="JUSTIFY">f) Organos responsables del archivo, precisando dependencia jerárquica en su caso;</p>
+<p align="JUSTIFY">g) Las oficinas ante las que se pudiesen efectuar las reclamaciones en ejercicio de los derechos de acceso, rectificación o supresión.</p>
+<p align="JUSTIFY">3. En las disposiciones que se dicten para la supresión de los registros informatizados se esta blecerá el destino de los mismos o las medidas que se adopten para su destrucción.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 23. </b>— (Supuestos especiales).</p>
+<p align="JUSTIFY">1. Quedarán sujetos al régimen de la presente ley, los datos personales que por haberse almacenado para fines administrativos, deban ser objeto de registro permanente en los bancos de datos de las fuerzas armadas, fuerzas de seguridad, organismos policiales o de inteligencia; y aquellos sobre antecedentes personales que proporcionen dichos bancos de datos a las autoridades administrativas o judiciales que los requieran en virtud de disposiciones legales.</p>
+<p align="JUSTIFY">2. El tratamiento de datos personales con fines de defensa nacional o seguridad pública por parte de las fuerzas armadas, fuerzas de seguridad, organismos policiales o inteligencia, sin consentimiento de los afectados, queda limitado a aquellos supuestos y categoría de datos que resulten necesarios para el estricto cumplimiento de las misiones legalmente asignadas a aquéllos para la defensa nacional, la seguridad pública o para la represión de los delitos. Los archivos, en tales casos, deberán ser específicos y establecidos al efecto, debiendo clasificarse por categorías, en función de su grado de fiabilidad.</p>
+<p align="JUSTIFY">3. Los datos personales registrados con fines policiales se cancelarán cuando no sean necesarios para las averiguaciones que motivaron su almacenamiento. </p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 24. </b>— (Archivos, registros o bancos de datos privados).</p>
+<p align="JUSTIFY">Los particulares que formen archivos, registros o bancos de datos que no sean para un uso exclusivamente personal deberán registrarse conforme lo previsto en el artículo 21.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 25. </b>— (Prestación de servicios informatizados de datos personales).</p>
+<p align="JUSTIFY">1. Cuando por cuenta de terceros se presten servicios de tratamiento de datos personales, éstos no podrán aplicarse o utilizarse con un fin distinto al que figure en el contrato de servicios, ni cederlos a otras personas, ni aun para su conservación.</p>
+<p align="JUSTIFY">2. Una vez cumplida la prestación contractual los datos personales tratados deberán ser destruidos, salvo que medie autorización expresa de aquel por cuenta de quien se prestan tales servicios cuando razonablemente se presuma la posibilidad de ulteriores encargos, en cuyo caso se podrá almacenar con las debidas condiciones de seguridad por un período de hasta dos años.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 26. </b>— (Prestación de servicios de información crediticia).</p>
+<p align="JUSTIFY">1. En la prestación de servicios de información crediticia sólo pueden tratarse datos personales de carácter patrimonial relativos a la solvencia económica y al crédito, obtenidos de fuentes accesibles al público o procedentes de informaciones facilitadas por el interesado o con su consentimiento.</p>
+<p align="JUSTIFY">2. Pueden tratarse igualmente datos personales relativos al cumplimiento o incumplimiento de obligaciones de contenido patrimonial, facilitados por el acreedor o por quien actúe por su cuenta o interés.</p>
+<p align="JUSTIFY">3. A solicitud del titular de los datos, el responsable o usuario del banco de datos, le comunicará las informaciones, evaluaciones y apreciaciones que sobre el mismo hayan sido comunicadas durante los últimos seis meses y y el nombre y domicilio del cesionario en el supuesto de tratarse de datos obtenidos por cesión.</p>
+<p align="JUSTIFY">4. Sólo se podrán archivar, registrar o ceder los datos personales que sean significativos para evaluar la solvencia económico-financiera de los afectados durante los últimos cinco años. Dicho plazo se reducirá a dos años cuando el deudor cancele o de otro modo extinga la obligación, debiéndose hace constar dicho hecho.</p>
+<p align="JUSTIFY">5. La prestación de servicios de información crediticia no requerirá el previo consentimiento del titular de los datos a los efectos de su cesión, ni la ulterior comunicación de ésta, cuando estén relacionados con el giro de las actividades comerciales o crediticias de los cesionarios.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 27. </b>— (Archivos, registros o bancos de datos con fines de publicidad).</p>
+<p align="JUSTIFY">1. En la recopilación de domicilios, reparto de documentos, publicidad o venta directa y otras actividades análogas, se podrán tratar datos que sean aptos para establecer perfiles determinados con fines promocionales, comerciales o publicitarios; o permitan establecer hábitos de consumo, cuando éstos figuren en documentos accesibles al público o hayan sido facilitados por los propios titulares u obtenidos con su consentimiento.</p>
+<p align="JUSTIFY">2. En los supuestos contemplados en el presente artículo, el titular de los datos podrá ejercer el derecho de acceso sin cargo alguno.</p>
+<p align="JUSTIFY">3. El titular podrá en cualquier momento solicitar el retiro o bloqueo de su nombre de los bancos de datos a los que se refiere el presente artículo.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 28. </b>— (Archivos, registros o bancos de datos relativos a encuestas).</p>
+<p align="JUSTIFY">1. Las normas de la presente ley no se aplicarán a las encuestas de opinión, mediciones y estadísticas relevadas conforme a Ley 17.622, trabajos de prospección de mercados, investigaciones científicas o médicas y actividades análogas, en la medida que los datos recogidos no puedan atribuirse a una persona determinada o determinable.</p>
+<p align="JUSTIFY">2. Si en el proceso de recolección de datos no resultara posible mantener el anonimato, se deberá utilizar una técnica de disociación, de modo que no permita identificar a persona alguna. </p>
+<p align="CENTER">Capítulo V</p>
+<p align="CENTER">Control</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 29. </b>— (Organo de Control).</p>
+<p align="JUSTIFY">1. El órgano de control deberá realizar todas las acciones necesarias para el cumplimiento de los objetivos y demás disposiciones de la presente ley. A tales efectos tendrá las siguientes funciones y atribuciones:</p>
+<p align="JUSTIFY">a) Asistir y asesorar a las personas que lo requieran acerca de los alcances de la presente y de los medios legales de que disponen para la defensa de los derechos que ésta garantiza;</p>
+<p align="JUSTIFY">b) Dictar las normas y reglamentaciones que se deben observar en el desarrollo de las actividades comprendidas por esta ley;</p>
+<p align="JUSTIFY">c) Realizar un censo de archivos, registros o bancos de datos alcanzados por la ley y mantener el registro permanente de los mismos;</p>
+<p align="JUSTIFY">d) Controlar la observancia de las normas sobre integridad y seguridad de datos por parte de los archivos, registros o bancos de datos. A tal efecto podrá solicitar autorización judicial para acceder a locales, equipos, o programas de tratamiento de datos a fin de verificar infracciones al cumplimiento de la presente ley;</p>
+<p align="JUSTIFY">e) Solicitar información a las entidades públicas y privadas, las que deberán proporcionar los antecedentes, documentos, programas u otros elementos relativos al tratamiento de los datos personales que se le requieran. En estos casos, la autoridad deberá garantizar la seguridad y confidencialidad de la información y elementos suministrados;</p>
+<p align="JUSTIFY">f) Imponer las sanciones administrativas que en su caso correspondan por violación a las normas de la presente ley y de las reglamentaciones que se dicten en su consecuencia;</p>
+<p align="JUSTIFY">g) Constituirse en querellante en las acciones penales que se promovieran por violaciones a la presente ley;</p>
+<p align="JUSTIFY">h) Controlar el cumplimiento de los requisitos y garantías que deben reunir los archivos o bancos de datos privados destinados a suministrar informes, para obtener la correspondiente inscripción en el Registro creado por esta ley.</p>
+<p align="JUSTIFY">2. <i>(Punto vetado por art. 1° del </i><a href="https://servicios.infoleg.gob.ar/infolegInternet/verNorma.do?id=64791"><i>Decreto N° 995/2000</i></a><i> B.O. 2/11/2000)</i></p><i>
+</i><p align="JUSTIFY">3.<b> </b><i>(Punto vetado por art. 1° del </i><a href="https://servicios.infoleg.gob.ar/infolegInternet/verNorma.do?id=64791"><i>Decreto N° 995/2000</i></a><i> B.O. 2/11/2000)</i></p><i>
+</i><p align="JUSTIFY">El Director tendrá dedicación exclusiva en su función, encontrándose alcanzado por las incompatibilidades fijadas por ley para los funcionarios públicos y podrá ser removido por el Poder Ejecutivo por mal desempeño de sus funciones.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 30. </b>— (Códigos de conducta).</p>
+<p align="JUSTIFY">1. Las asociaciones o entidades representativas de responsables o usuarios de bancos de datos de titularidad privada podrán elaborar códigos de conducta de práctica profesional, que establezcan normas para el tratamiento de datos personales que tiendan a asegurar y mejorar las condiciones de operación de los sistemas de información en función de los principios establecidos en la presente ley.</p>
+<p align="JUSTIFY">2. Dichos códigos deberán ser inscriptos en el registro que al efecto lleve el organismo de control, quien podrá denegar la inscripción cuando considere que no se ajustan a las disposiciones legales y reglamentarias sobre la materia.</p>
+<p align="CENTER">Capítulo VI</p>
+<p align="CENTER">Sanciones</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 31. </b>— (Sanciones administrativas).</p>
+<p align="JUSTIFY">1. Sin perjuicio de las responsabilidades administrativas que correspondan en los casos de responsables o usuarios de bancos de datos públicos; de la responsabilidad por daños y perjuicios derivados de la inobservancia de la presente ley, y de las sanciones penales que correspondan, el organismo de control podrá aplicar las sanciones de apercibimiento, suspensión, multa de mil pesos ($ 1.000.-) a cien mil pesos ($ 100.000.-), clausura o cancelación del archivo, registro o banco de datos.</p>
+<p align="JUSTIFY">2. La reglamentación determinará las condiciones y procedimientos para la aplicación de las sanciones previstas, las que deberán graduarse en relación a la gravedad y extensión de la violación y de los perjuicios derivados de la infracción, garantizando el principio del debido proceso.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 32. </b>— (Sanciones penales).</p>
+<p align="JUSTIFY">1. Incorpórase como artículo 117 bis del Código Penal, el siguiente:</p>
+<p align="JUSTIFY">"1°. Será reprimido con la pena de prisión de un mes a dos años el que insertara o hiciera insertar a sabiendas datos falsos en un archivo de datos personales.</p>
+<p align="JUSTIFY">2°. La pena será de seis meses a tres años, al que proporcionara a un tercero a sabiendas información falsa contenida en un archivo de datos personales.</p>
+<p align="JUSTIFY">3°. La escala penal se aumentará en la mitad del mínimo y del máximo, cuando del hecho se derive perjuicio a alguna persona.</p>
+<p align="JUSTIFY">4°. Cuando el autor o responsable del ilícito sea funcionario público en ejercicio de sus funciones, se le aplicará la accesoria de inhabilitación para el desempeño de cargos públicos por el doble del tiempo que el de la condena".</p>
+<p align="JUSTIFY">2. Incorpórase como artículo 157 bis del Código Penal el siguiente:</p>
+<p align="JUSTIFY">"Será reprimido con la pena de prisión de un mes a dos años el que:</p>
+<p align="JUSTIFY">1°. A sabiendas e ilegítimamente, o violando sistemas de confidencialidad y seguridad de datos, accediere, de cualquier forma, a un banco de datos personales;</p>
+<p align="JUSTIFY">2°. Revelare a otro información registrada en un banco de datos personales cuyo secreto estuviere obligado a preservar por disposición de una ley. </p>
+<p align="JUSTIFY">Cuando el autor sea funcionario público sufrirá, además, pena de inhabilitación especial de uno a cuatro años".</p>
+<p align="CENTER">Capítulo VII</p>
+<p align="CENTER">Acción de protección de los datos personales</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 33. </b>— (Procedencia).</p>
+<p align="JUSTIFY">1. La acción de protección de los datos personales o de hábeas data procederá:</p>
+<p align="JUSTIFY">a) para tomar conocimiento de los datos personales almacenados en archivos, registros o bancos de datos públicos o privados destinados a proporcionar informes, y de la finalidad de aquéllos;</p>
+<p align="JUSTIFY">b) en los casos en que se presuma la falsedad, inexactitud, desactualización de la información de que se trata, o el tratamiento de datos cuyo registro se encuentra prohibido en la presente ley, para exigir su rectificación, supresión, confidencialidad o actualización.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 34. </b>— (Legitimación activa).</p>
+<p align="JUSTIFY">La acción de protección de los datos personales o de hábeas data podrá ser ejercida por el afectado, sus tutores o curadores y los sucesores de las personas físicas, sean en línea directa o colateral hasta el segundo grado, por sí o por intermedio de apoderado.</p>
+<p align="JUSTIFY">Cuando la acción sea ejercida por personas de existencia ideal, deberá ser interpuesta por sus representantes legales, o apoderados que éstas designen al efecto.</p>
+<p align="JUSTIFY">En el proceso podrá intervenir en forma coadyuvante el Defensor del Pueblo.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 35. </b>— (Legitimación pasiva).</p>
+<p align="JUSTIFY">La acción procederá respecto de los responsables y usuarios de bancos de datos públicos, y de los privados destinados a proveer informes.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 36. </b>— (Competencia).</p>
+<p align="JUSTIFY">Será competente para entender en esta acción el juez del domicilio del actor; el del domicilio del demandado; el del lugar en el que el hecho o acto se exteriorice o pudiera tener efecto, a elección del actor.</p>
+<p align="JUSTIFY">Procederá la competencia federal:</p>
+<p align="JUSTIFY">a) cuando se interponga en contra de archivos de datos públicos de organismos nacionales, y</p>
+<p align="JUSTIFY">b) cuando los archivos de datos se encuentren interconectados en redes interjurisdicciones, nacionales o internacionales.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 37. </b>— (Procedimiento aplicable).</p>
+<p align="JUSTIFY">La acción de hábeas data tramitará según las disposiciones de la presente ley y por el procedimiento que corresponde a la acción de amparo común y supletoriamente por las normas del Código Procesal Civil y Comercial de la Nación, en lo atinente al juicio sumarísimo.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 38. </b>— (Requisitos de la demanda).</p>
+<p align="JUSTIFY">1. La demanda deberá interponerse por escrito, individualizando con la mayor precisión posible el nombre y domicilio del archivo, registro o banco de datos y, en su caso, el nombre del responsable o usuario del mismo.</p>
+<p align="JUSTIFY">En el caso de los archivos, registros o bancos públicos, se procurará establecer el organismo estatal del cual dependen.</p>
+<p align="JUSTIFY">2. El accionante deberá alegar las razones por las cuales entiende que en el archivo, registro o banco de datos individualizado obra información referida a su persona; los motivos por los cuales considera que la información que le atañe resulta discriminatoria, falsa o inexacta y justificar que se han cumplido los recaudos que hacen al ejercicio de los derechos que le reconoce la presente ley.</p>
+<p align="JUSTIFY">3. El afectado podrá solicitar que mientras dure el procedimiento, el registro o banco de datos asiente que la información cuestionada está sometida a un proceso judicial.</p>
+<p align="JUSTIFY">4. El Juez podrá disponer el bloqueo provisional del archivo en lo referente al dato personal motivo del juicio cuando sea manifiesto el carácter discriminatorio, falso o inexacto de la información de que se trate.</p>
+<p align="JUSTIFY">5. A los efectos de requerir información al archivo, registro o banco de datos involucrado, el criterio judicial de apreciación de las circunstancias requeridas en los puntos 1 y 2 debe ser amplio.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 39. </b>— (Trámite).</p>
+<p align="JUSTIFY">1. Admitida la acción el juez requerirá al archivo, registro o banco de datos la remisión de la información concerniente al accionante. Podrá asimismo solicitar informes sobre el soporte técnico de datos, documentación de base relativa a la recolección y cualquier otro aspecto que resulte conducente a la resolución de la causa que estime procedente.</p>
+<p align="JUSTIFY">2. El plazo para contestar el informe no podrá ser mayor de cinco días hábiles, el que podrá ser ampliado prudencialmente por el juez.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 40. </b>— (Confidencialidad de la información).</p>
+<p align="JUSTIFY">1. Los registros, archivos o bancos de datos privados no podrán alegar la confidencialidad de la información que se les requiere salvo el caso en que se afecten las fuentes de información periodística. </p>
+<p align="JUSTIFY">2. Cuando un archivo, registro o banco de datos público se oponga a la remisión del informe solicitado con invocación de las excepciones al derecho de acceso, rectificación o supresión, autorizadas por la presente ley o por una ley específica; deberá acreditar los extremos que hacen aplicable la excepción legal. En tales casos, el juez podrá tomar conocimiento personal y directo de los datos solicitados asegurando el mantenimiento de su confidencialidad.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 41. </b>— (Contestación del informe).</p>
+<p align="JUSTIFY">Al contestar el informe, el archivo, registro o banco de datos deberá expresar las razones por las cuales incluyó la información cuestionada y aquellas por las que no evacuó el pedido efectuado por el interesado, de conformidad a lo establecido en los artículos 13 a 15 de la ley.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 42. </b>— (Ampliación de la demanda).</p>
+<p align="JUSTIFY">Contestado el informe, el actor podrá, en el término de tres días, ampliar el objeto de la demanda solicitando la supresión, rectificación, confidencialidad o actualización de sus datos personales, en los casos que resulte procedente a tenor de la presente ley, ofreciendo en el mismo acto la prueba pertinente. De esta presentación se dará traslado al demandado por el término de tres días.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 43. </b>— (Sentencia).</p>
+<p align="JUSTIFY">1. Vencido el plazo para la contestación del informe o contestado el mismo, y en el supuesto del artículo 42, luego de contestada la ampliación, y habiendo sido producida en su caso la prueba, el juez dictará sentencia.</p>
+<p align="JUSTIFY">2. En el caso de estimarse procedente la acción, se especificará si la información debe ser suprimida, rectificada, actualizada o declarada confidencial, estableciendo un plazo para su cumplimiento.</p>
+<p align="JUSTIFY">3. El rechazo de la acción no constituye presunción respecto de la responsabilidad en que hubiera podido incurrir el demandante.</p>
+<p align="JUSTIFY">4. En cualquier caso, la sentencia deberá ser comunicada al organismo de control, que deberá llevar un registro al efecto.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 44. </b>— (Ambito de aplicación).</p>
+<p align="JUSTIFY">Las normas de la presente ley contenidas en los Capítulos I, II, III y IV, y artículo 32 son de orden público y de aplicación en lo pertinente en todo el territorio nacional.</p>
+<p align="JUSTIFY">Se invita a las provincias a adherir a las normas de esta ley que fueren de aplicación exclusiva en jurisdicción nacional.</p>
+<p align="JUSTIFY">La jurisdicción federal regirá respecto de los registros, archivos, bases o bancos de datos interconectados en redes de alcance interjurisdiccional, nacional o internacional.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 45. </b>— El Poder Ejecutivo Nacional deberá reglamentar la presente ley y establecer el organismo de control dentro de los ciento ochenta días de su promulgación.</p>
+<b></b><p align="JUSTIFY"><b>ARTICULO 46. </b>— (Disposiciones transitorias).</p>
+<p align="JUSTIFY">Los archivos, registros, bases o bancos de datos destinados a proporcionar informes, existentes al momento de la sanción de la presente ley, deberán inscribirse en el registro que se habilite conforme a lo dispuesto en el artículo 21 y adecuarse a lo que dispone el presente régimen dentro del plazo que al efecto establezca la reglamentación.</p>
+<i></i><p align="JUSTIFY"><i>(<b>Nota Infoleg</b>: por art. 2° del </i><a href="https://servicios.infoleg.gob.ar/infolegInternet/verNorma.do?id=70368"><i>Decreto N° 1558/2001</i></a><i> B.O. 3/12/2001 se establece en CIENTO OCHENTA (180) días el plazo previsto en el presente artículo)</i></p><i>
+</i><b></b><p align="JUSTIFY"><b>ARTICULO 47. — </b>Los bancos de datos destinados a prestar servicios de información crediticia deberán eliminar y omitir el asiento en el futuro de todo dato referido a obligaciones y calificaciones asociadas de las personas físicas y jurídicas cuyas obligaciones comerciales se hubieran constituido en mora, o cuyas obligaciones financieras hubieran sido clasificadas con categoría 2, 3, 4 ó 5, según normativas del Banco Central de la República Argentina, en ambos casos durante el período comprendido entre el 1º de enero del año 2000 y el 10 de diciembre de 2003, siempre y cuando esas deudas hubieran sido canceladas o regularizadas al momento de entrada en vigencia de la presente ley o lo sean dentro de los 180 días posteriores a la misma. La suscripción de un plan de pagos por parte del deudor, o la homologación del acuerdo preventivo o del acuerdo preventivo extrajudicial importará la regularización de la deuda, a los fines de esta ley.</p>
+<p align="JUSTIFY">El Banco Central de la República Argentina establecerá los mecanismos que deben cumplir las Entidades Financieras para informar a dicho organismo los datos necesarios para la determinación de los casos encuadrados. Una vez obtenida dicha información, el Banco Central de la República Argentina implementará las medidas necesarias para asegurar que todos aquellos que consultan los datos de su Central de Deudores sean informados de la procedencia e implicancias de lo aquí dispuesto.</p>
+<p align="JUSTIFY">Toda persona que considerase que sus obligaciones canceladas o regularizadas están incluidas en lo prescripto en el presente artículo puede hacer uso de los derechos de acceso, rectificación y actualización en relación con lo establecido.</p>
+<p align="JUSTIFY">Sin perjuicio de lo expuesto en los párrafos precedentes, el acreedor debe comunicar a todo archivo, registro o banco de datos al que hubiera cedido datos referentes al incumplimiento de la obligación original, su cancelación o regularización.</p>
+<i></i><p align="JUSTIFY"><i>(Artículo incorporado por art. 1° de la </i><a href="https://servicios.infoleg.gob.ar/infolegInternet/verNorma.do?id=136483"><i>Ley N° 26.343</i></a><i> B.O. 9/1/2008)</i></p><i>
+</i><b></b><p align="JUSTIFY"><b>ARTICULO 48. </b>— Comuníquese al Poder Ejecutivo. </p>
+<p align="CENTER">DADA EN LA SALA DE SESIONES DEL CONGRESO ARGENTINO, EN BUENOS AIRES, A LOS CUATRO DIAS DEL MES DE OCTUBRE DEL AÑO DOS MIL.</p>
+<p align="CENTER">— REGISTRADO BAJO EL N° 25.326 —</p>
+<p align="JUSTIFY">RAFAEL PASCUAL. — JOSE GENOUD. — Guillermo Aramburu. — Mario L. Pontaquarto.</p>
+<b><p><a name="1"></a>Antecedentes Normativos</p>
+</b><i></i><p align="JUSTIFY"><i>- Artículo 47 vetado por art. 2° del </i><a href="https://servicios.infoleg.gob.ar/infolegInternet/verNorma.do?id=64791"><i>Decreto N° 995/2000</i></a><i> B.O. 2/11/2000.</i></p>
+
+</body></html>

--- a/data/ley_25326.json
+++ b/data/ley_25326.json
@@ -1,0 +1,346 @@
+{
+  "id": "ley_25326",
+  "title": "Ley de Protección de los Datos Personales",
+  "shortName": "LPDP",
+  "officialNumber": "Ley 25.326",
+  "source": "https://servicios.infoleg.gob.ar/infolegInternet/anexos/60000-64999/64790/texact.htm",
+  "lastUpdated": "2026-05-01",
+  "articles": [
+    {
+      "number": "1",
+      "text": "(Objeto).\nLa presente ley tiene por objeto la protección integral de los datos personales asentados en archivos, registros, bancos de datos, u otros medios técnicos de tratamiento de datos, sean éstos públicos, o privados destinados a dar informes, para garantizar el derecho al honor y a la intimidad de las personas, así como también el acceso a la información que sobre las mismas se registre, de conformidad a lo establecido en el artículo 43, párrafo tercero de la Constitución Nacional. \nLas disposiciones de la presente ley también serán aplicables, en cuanto resulte pertinente, a los datos relativos a personas de existencia ideal.\nEn ningún caso se podrán afectar la base de datos ni las fuentes de información periodísticas.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "2",
+      "text": "(Definiciones). \nA los fines de la presente ley se entiende por:\n— Datos personales: Información de cualquier tipo referida a personas físicas o de existencia ideal determinadas o determinables.\n— Datos sensibles: Datos personales que revelan origen racial y étnico, opiniones políticas, convicciones religiosas, filosóficas o morales, afiliación sindical e información referente a la salud o a la vida sexual.\n— Archivo, registro, base o banco de datos: Indistintamente, designan al conjunto organizado de datos personales que sean objeto de tratamiento o procesamiento, electrónico o no, cualquiera que fuere la modalidad de su formación, almacenamiento, organización o acceso.\n— Tratamiento de datos: Operaciones y procedimientos sistemáticos, electrónicos o no, que permitan la recolección, conservación, ordenación, almacenamiento, modificación, relacionamiento, evaluación, bloqueo, destrucción, y en general el procesamiento de datos personales, así como también su cesión a terceros a través de comunicaciones, consultas, interconexiones o transferencias.\n— Responsable de archivo, registro, base o banco de datos: Persona física o de existencia ideal pública o privada, que es titular de un archivo, registro, base o banco de datos.\n— Datos informatizados: Los datos personales sometidos al tratamiento o procesamiento electrónico o automatizado.\n— Titular de los datos: Toda persona física o persona de existencia ideal con domicilio legal o delegaciones o sucursales en el país, cuyos datos sean objeto del tratamiento al que se refiere la presente ley.\n— Usuario de datos: Toda persona, pública o privada que realice a su arbitrio el tratamiento de datos, ya sea en archivos, registros o bancos de datos propios o a través de conexión con los mismos.\n— Disociación de datos: Todo tratamiento de datos personales de manera que la información obtenida no pueda asociarse a persona determinada o determinable.\nCapítulo II\nPrincipios generales relativos a la protección de datos",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "3",
+      "text": "(Archivos de datos – Licitud).\nLa formación de archivos de datos será lícita cuando se encuentren debidamente inscriptos, observando en su operación los principios que establece la presente ley y las reglamentaciones que se dicten en su consecuencia.\nLos archivos de datos no pueden tener finalidades contrarias a las leyes o a la moral pública.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "4",
+      "text": "(Calidad de los datos). \n1. Los datos personales que se recojan a los efectos de su tratamiento deben ser ciertos, adecuados, pertinentes y no excesivos en relación al ámbito y finalidad para los que se hubieren obtenido. \n2. La recolección de datos no puede hacerse por medios desleales, fraudulentos o en forma contraria a las disposiciones de la presente ley.\n3. Los datos objeto de tratamiento no pueden ser utilizados para finalidades distintas o incompatibles con aquellas que motivaron su obtención.\n4. Los datos deben ser exactos y actualizarse en el caso de que ello fuere necesario.\n5. Los datos total o parcialmente inexactos, o que sean incompletos, deben ser suprimidos y sustituidos, o en su caso completados, por el responsable del archivo o base de datos cuando se tenga conocimiento de la inexactitud o carácter incompleto de la información de que se trate, sin perjuicio de los derechos del titular establecidos en el artículo 16 de la presente ley.\n6. Los datos deben ser almacenados de modo que permitan el ejercicio del derecho de acceso de su titular.\n7. Los datos deben ser destruidos cuando hayan dejado de ser necesarios o pertinentes a los fines para los cuales hubiesen sido recolectados.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "5",
+      "text": "(Consentimiento).\n1. El tratamiento de datos personales es ilícito cuando el titular no hubiere prestado su consentimiento libre, expreso e informado, el que deberá constar por escrito, o por otro medio que permita se le equipare, de acuerdo a las circunstancias.\nEl referido consentimiento prestado con otras declaraciones, deberá figurar en forma expresa y destacada, previa notificación al requerido de datos, de la información descrita en el artículo 6° de la presente ley.\n2. No será necesario el consentimiento cuando: \na) Los datos se obtengan de fuentes de acceso público irrestricto;\nb) Se recaben para el ejercicio de funciones propias de los poderes del Estado o en virtud de una obligación legal;\nc) Se trate de listados cuyos datos se limiten a nombre, documento nacional de identidad, identificación tributaria o previsional, ocupación, fecha de nacimiento y domicilio;\nd) Deriven de una relación contractual, científica o profesional del titular de los datos, y resulten necesarios para su desarrollo o cumplimiento;\ne) Se trate de las operaciones que realicen las entidades financieras y de las informaciones que reciban de sus clientes conforme las disposiciones del artículo 39 de la Ley 21.526.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "6",
+      "text": "(Información). \nCuando se recaben datos personales se deberá informar previamente a sus titulares en forma expresa y clara:\na) La finalidad para la que serán tratados y quiénes pueden ser sus destinatarios o clase de destinatarios;\nb) La existencia del archivo, registro, banco de datos, electrónico o de cualquier otro tipo, de que se trate y la identidad y domicilio de su responsable;\nc) El carácter obligatorio o facultativo de las respuestas al cuestionario que se le proponga, en especial en cuanto a los datos referidos en el artículo siguiente;\nd) Las consecuencias de proporcionar los datos, de la negativa a hacerlo o de la inexactitud de los mismos;\ne) La posibilidad del interesado de ejercer los derechos de acceso, rectificación y supresión de los datos.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "7",
+      "text": "(Categoría de datos).\n1. Ninguna persona puede ser obligada a proporcionar datos sensibles.\n2. Los datos sensibles sólo pueden ser recolectados y objeto de tratamiento cuando medien razones de interés general autorizadas por ley. También podrán ser tratados con finalidades estadísticas o científicas cuando no puedan ser identificados sus titulares.\n3. Queda prohibida la formación de archivos, bancos o registros que almacenen información que directa o indirectamente revele datos sensibles. Sin perjuicio de ello, la Iglesia Católica, las asociaciones religiosas y las organizaciones políticas y sindicales podrán llevar un registro de sus miembros.\n4. Los datos relativos a antecedentes penales o contravencionales sólo pueden ser objeto de tratamiento por parte de las autoridades públicas competentes, en el marco de las leyes y reglamentaciones respectivas.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "8",
+      "text": "(Datos relativos a la salud).\nLos establecimientos sanitarios públicos o privados y los profesionales vinculados a las ciencias de la salud pueden recolectar y tratar los datos personales relativos a la salud física o mental de los pacientes que acudan a los mismos o que estén o hubieren estado bajo tratamiento de aquéllos, respetando los principios del secreto profesional.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "9",
+      "text": "(Seguridad de los datos).\n1. El responsable o usuario del archivo de datos debe adoptar las medidas técnicas y organizativas que resulten necesarias para garantizar la seguridad y confidencialidad de los datos personales, de modo de evitar su adulteración, pérdida, consulta o tratamiento no autorizado, y que permitan detectar desviaciones, intencionales o no, de información, ya sea que los riesgos provengan de la acción humana o del medio técnico utilizado.\n2. Queda prohibido registrar datos personales en archivos, registros o bancos que no reúnan condiciones técnicas de integridad y seguridad.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "10",
+      "text": "(Deber de confidencialidad).\n1. El responsable y las personas que intervengan en cualquier fase del tratamiento de datos personales están obligados al secreto profesional respecto de los mismos. Tal obligación subsistirá aun después de finalizada su relación con el titular del archivo de datos.\n2. El obligado podrá ser relevado del deber de secreto por resolución judicial y cuando medien razones fundadas relativas a la seguridad pública, la defensa nacional o la salud pública.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "11",
+      "text": "(Cesión).\n1. Los datos personales objeto de tratamiento sólo pueden ser cedidos para el cumplimiento de los fines directamente relacionados con el interés legítimo del cedente y del cesionario y con el previo consentimiento del titular de los datos, al que se le debe informar sobre la finalidad de la cesión e identificar al cesionario o los elementos que permitan hacerlo.\n2. El consentimiento para la cesión es revocable.\n3. El consentimiento no es exigido cuando:\na) Así lo disponga una ley;\nb) En los supuestos previstos en el artículo 5° inciso 2;\nc) Se realice entre dependencias de los órganos del Estado en forma directa, en la medida del cumplimiento de sus respectivas competencias;\nd) Se trate de datos personales relativos a la salud, y sea necesario por razones de salud pública, de emergencia o para la realización de estudios epidemiológicos, en tanto se preserve la identidad de los titulares de los datos mediante mecanismos de disociación adecuados;\ne) Se hubiera aplicado un procedimiento de disociación de la información, de modo que los titulares de los datos sean inidentificables.\n4. El cesionario quedará sujeto a las mismas obligaciones legales y reglamentarias del cedente y éste responderá solidaria y conjuntamente por la observancia de las mismas ante el organismo de control y el titular de los datos de que se trate.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "12",
+      "text": "(Transferencia internacional).\n1. Es prohibida la transferencia de datos personales de cualquier tipo con países u organismos internacionales o supranacionales, que no propocionen niveles de protección adecuados.\n2. La prohibición no regirá en los siguientes supuestos:\na) Colaboración judicial internacional;\nb) Intercambio de datos de carácter médico, cuando así lo exija el tratamiento del afectado, o una investigación epidemiológica, en tanto se realice en los términos del inciso e) del artículo anterior; \nc) Transferencias bancarias o bursátiles, en lo relativo a las transacciones respectivas y conforme la legislación que les resulte aplicable;\nd) Cuando la transferencia se hubiera acordado en el marco de tratados internacionales en los cuales la República Argentina sea parte;\ne) Cuando la transferencia tenga por objeto la cooperación internacional entre organismos de inteligencia para la lucha contra el crimen organizado, el terrorismo y el narcotráfico.\nCapítulo III\nDerechos de los titulares de datos",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "13",
+      "text": "(Derecho de Información).\nToda persona puede solicitar información al organismo de control relativa a la existencia de archivos, registros, bases o bancos de datos personales, sus finalidades y la identidad de sus responsables.\nEl registro que se lleve al efecto será de consulta pública y gratuita.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "14",
+      "text": "(Derecho de acceso).\n1. El titular de los datos, previa acreditación de su identidad, tiene derecho a solicitar y obtener información de sus datos personales incluidos en los bancos de datos públicos, o privados destinados a proveer informes.\n2. El responsable o usuario debe proporcionar la información solicitada dentro de los diez días corridos de haber sido intimado fehacientemente. \nVencido el plazo sin que se satisfaga el pedido, o si evacuado el informe, éste se estimara insuficiente, quedará expedita la acción de protección de los datos personales o de hábeas data prevista en esta ley.\n3. El derecho de acceso a que se refiere este artículo sólo puede ser ejercido en forma gratuita a intervalos no inferiores a seis meses, salvo que se acredite un interés legítimo al efecto.\n4. El ejercicio del derecho al cual se refiere este artículo en el caso de datos de personas fallecidas le corresponderá a sus sucesores universales.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "15",
+      "text": "(Contenido de la información).\n1. La información debe ser suministrada en forma clara, exenta de codificaciones y en su caso acompañada de una explicación, en lenguaje accesible al conocimiento medio de la población, de los términos que se utilicen.\n2. La información debe ser amplia y versar sobre la totalidad del registro perteneciente al titular, aun cuando el requerimiento sólo comprenda un aspecto de los datos personales. En ningún caso el informe podrá revelar datos pertenecientes a terceros, aun cuando se vinculen con el interesado. \n3. La información, a opción del titular, podrá suministrarse por escrito, por medios electrónicos, telefónicos, de imagen, u otro idóneo a tal fin.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "16",
+      "text": "(Derecho de rectificación, actualización o supresión).\n1. Toda persona tiene derecho a que sean rectificados, actualizados y, cuando corresponda, suprimidos o sometidos a confidencialidad los datos personales de los que sea titular, que estén incluidos en un banco de datos.\n2. El responsable o usuario del banco de datos, debe proceder a la rectificación, supresión o actualización de los datos personales del afectado, realizando las operaciones necesarias a tal fin en el plazo máximo de cinco días hábiles de recibido el reclamo del titular de los datos o advertido el error o falsedad.\n3. El incumplimiento de esta obligación dentro del término acordado en el inciso precedente, habilitará al interesado a promover sin más la acción de protección de los datos personales o de hábeas data prevista en la presente ley.\n4. En el supuesto de cesión, o transferencia de datos, el responsable o usuario del banco de datos debe notificar la rectificación o supresión al cesionario dentro del quinto día hábil de efectuado el tratamiento del dato.\n5. La supresión no procede cuando pudiese causar perjuicios a derechos o intereses legítimos de terceros, o cuando existiera una obligación legal de conservar los datos.\n6. Durante el proceso de verificación y rectificación del error o falsedad de la información que se trate, el responsable o usuario del banco de datos deberá o bien bloquear el archivo, o consignar al proveer información relativa al mismo la circunstancia de que se encuentra sometida a revisión.\n7. Los datos personales deben ser conservados durante los plazos previstos en las disposiciones aplicables o en su caso, en las contractuales entre el responsable o usuario del banco de datos y el titular de los datos.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "17",
+      "text": "(Excepciones).\n1. Los responsables o usuarios de bancos de datos públicos pueden, mediante decisión fundada, denegar el acceso, rectificación o la supresión en función de la protección de la defensa de la Nación, del orden y la seguridad públicos, o de la protección de los derechos e intereses de terceros.\n2. La información sobre datos personales también puede ser denegada por los responsables o usuarios de bancos de datos públicos, cuando de tal modo se pudieran obstaculizar actuaciones judiciales o administrativas en curso vinculadas a la investigación sobre el cumplimiento de obligaciones tributarias o previsionales, el desarrollo de funciones de control de la salud y del medio ambiente, la investigación de delitos penales y la verificación de infracciones administrativas. La resolución que así lo disponga debe ser fundada y notificada al afectado.\n3. Sin perjuicio de lo establecido en los incisos anteriores, se deberá brindar acceso a los registros en cuestión en la oportunidad en que el afectado tenga que ejercer su derecho de defensa.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "18",
+      "text": "(Comisiones legislativas).\nLas Comisiones de Defensa Nacional y la Comisión Bicameral de Fiscalización de los Organos y Actividades de Seguridad Interior e Inteligencia del Congreso de la Nación y la Comisión de Seguridad Interior de la Cámara de Diputados de la Nación, o las que las sustituyan, tendrán acceso a los archivos o bancos de datos referidos en el artículo 23 inciso 2 por razones fundadas y en aquellos aspectos que constituyan materia de competencia de tales Comisiones.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "19",
+      "text": "(Gratuidad).\nLa rectificación, actualización o supresión de datos personales inexactos o incompletos que obren en registros públicos o privados se efectuará sin cargo alguno para el interesado.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "20",
+      "text": "(Impugnación de valoraciones personales).\n1. Las decisiones judiciales o los actos administrativos que impliquen apreciación o valoración de conductas humanas, no podrán tener como único fundamento el resultado del tratamiento informatizado de datos personales que suministren una definición del perfil o personalidad del interesado. \n2. Los actos que resulten contrarios a la disposición precedente serán insanablemente nulos. \nCapítulo IV\nUsuarios y responsables de archivos, registros y bancos de datos",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "21",
+      "text": "(Registro de archivos de datos. Inscripción).\n1. Todo archivo, registro, base o banco de datos público, y privado destinado a proporcionar informes debe inscribirse en el Registro que al efecto habilite el organismo de control.\n2. El registro de archivos de datos debe comprender como mínimo la siguiente información: \na) Nombre y domicilio del responsable;\nb) Características y finalidad del archivo;\nc) Naturaleza de los datos personales contenidos en cada archivo;\nd) Forma de recolección y actualización de datos;\ne) Destino de los datos y personas físicas o de existencia ideal a las que pueden ser transmitidos;\nf) Modo de interrelacionar la información registrada;\ng) Medios utilizados para garantizar la seguridad de los datos, debiendo detallar la categoría de personas con acceso al tratamiento de la información;\nh) Tiempo de conservación de los datos;\ni) Forma y condiciones en que las personas pueden acceder a los datos referidos a ellas y los procedimientos a realizar para la rectificación o actualización de los datos.\n3) Ningún usuario de datos podrá poseer datos personales de naturaleza distinta a los declarados en el registro.\nEl incumplimiento de estos requisitos dará lugar a las sanciones administrativas previstas en el capítulo VI de la presente ley.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "22",
+      "text": "(Archivos, registros o bancos de datos públicos).\n1. Las normas sobre creación, modificación o supresión de archivos, registros o bancos de datos pertenecientes a organismos públicos deben hacerse por medio de disposición general publicada en el Boletín Oficial de la Nación o diario oficial.\n2. Las disposiciones respectivas, deben indicar:\na) Características y finalidad del archivo;\nb) Personas respecto de las cuales se pretenda obtener datos y el carácter facultativo u obligatorio de su suministro por parte de aquéllas;\nc) Procedimiento de obtención y actualización de los datos;\nd) Estructura básica del archivo, informatizado o no, y la descripción de la naturaleza de los datos personales que contendrán;\ne) Las cesiones, transferencias o interconexiones previstas;\nf) Organos responsables del archivo, precisando dependencia jerárquica en su caso;\ng) Las oficinas ante las que se pudiesen efectuar las reclamaciones en ejercicio de los derechos de acceso, rectificación o supresión.\n3. En las disposiciones que se dicten para la supresión de los registros informatizados se esta blecerá el destino de los mismos o las medidas que se adopten para su destrucción.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "23",
+      "text": "(Supuestos especiales).\n1. Quedarán sujetos al régimen de la presente ley, los datos personales que por haberse almacenado para fines administrativos, deban ser objeto de registro permanente en los bancos de datos de las fuerzas armadas, fuerzas de seguridad, organismos policiales o de inteligencia; y aquellos sobre antecedentes personales que proporcionen dichos bancos de datos a las autoridades administrativas o judiciales que los requieran en virtud de disposiciones legales.\n2. El tratamiento de datos personales con fines de defensa nacional o seguridad pública por parte de las fuerzas armadas, fuerzas de seguridad, organismos policiales o inteligencia, sin consentimiento de los afectados, queda limitado a aquellos supuestos y categoría de datos que resulten necesarios para el estricto cumplimiento de las misiones legalmente asignadas a aquéllos para la defensa nacional, la seguridad pública o para la represión de los delitos. Los archivos, en tales casos, deberán ser específicos y establecidos al efecto, debiendo clasificarse por categorías, en función de su grado de fiabilidad.\n3. Los datos personales registrados con fines policiales se cancelarán cuando no sean necesarios para las averiguaciones que motivaron su almacenamiento.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "24",
+      "text": "(Archivos, registros o bancos de datos privados).\nLos particulares que formen archivos, registros o bancos de datos que no sean para un uso exclusivamente personal deberán registrarse conforme lo previsto en el artículo 21.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "25",
+      "text": "(Prestación de servicios informatizados de datos personales).\n1. Cuando por cuenta de terceros se presten servicios de tratamiento de datos personales, éstos no podrán aplicarse o utilizarse con un fin distinto al que figure en el contrato de servicios, ni cederlos a otras personas, ni aun para su conservación.\n2. Una vez cumplida la prestación contractual los datos personales tratados deberán ser destruidos, salvo que medie autorización expresa de aquel por cuenta de quien se prestan tales servicios cuando razonablemente se presuma la posibilidad de ulteriores encargos, en cuyo caso se podrá almacenar con las debidas condiciones de seguridad por un período de hasta dos años.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "26",
+      "text": "(Prestación de servicios de información crediticia).\n1. En la prestación de servicios de información crediticia sólo pueden tratarse datos personales de carácter patrimonial relativos a la solvencia económica y al crédito, obtenidos de fuentes accesibles al público o procedentes de informaciones facilitadas por el interesado o con su consentimiento.\n2. Pueden tratarse igualmente datos personales relativos al cumplimiento o incumplimiento de obligaciones de contenido patrimonial, facilitados por el acreedor o por quien actúe por su cuenta o interés.\n3. A solicitud del titular de los datos, el responsable o usuario del banco de datos, le comunicará las informaciones, evaluaciones y apreciaciones que sobre el mismo hayan sido comunicadas durante los últimos seis meses y y el nombre y domicilio del cesionario en el supuesto de tratarse de datos obtenidos por cesión.\n4. Sólo se podrán archivar, registrar o ceder los datos personales que sean significativos para evaluar la solvencia económico-financiera de los afectados durante los últimos cinco años. Dicho plazo se reducirá a dos años cuando el deudor cancele o de otro modo extinga la obligación, debiéndose hace constar dicho hecho.\n5. La prestación de servicios de información crediticia no requerirá el previo consentimiento del titular de los datos a los efectos de su cesión, ni la ulterior comunicación de ésta, cuando estén relacionados con el giro de las actividades comerciales o crediticias de los cesionarios.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "27",
+      "text": "(Archivos, registros o bancos de datos con fines de publicidad).\n1. En la recopilación de domicilios, reparto de documentos, publicidad o venta directa y otras actividades análogas, se podrán tratar datos que sean aptos para establecer perfiles determinados con fines promocionales, comerciales o publicitarios; o permitan establecer hábitos de consumo, cuando éstos figuren en documentos accesibles al público o hayan sido facilitados por los propios titulares u obtenidos con su consentimiento.\n2. En los supuestos contemplados en el presente artículo, el titular de los datos podrá ejercer el derecho de acceso sin cargo alguno.\n3. El titular podrá en cualquier momento solicitar el retiro o bloqueo de su nombre de los bancos de datos a los que se refiere el presente artículo.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "28",
+      "text": "(Archivos, registros o bancos de datos relativos a encuestas).\n1. Las normas de la presente ley no se aplicarán a las encuestas de opinión, mediciones y estadísticas relevadas conforme a Ley 17.622, trabajos de prospección de mercados, investigaciones científicas o médicas y actividades análogas, en la medida que los datos recogidos no puedan atribuirse a una persona determinada o determinable.\n2. Si en el proceso de recolección de datos no resultara posible mantener el anonimato, se deberá utilizar una técnica de disociación, de modo que no permita identificar a persona alguna. \nCapítulo V\nControl",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "29",
+      "text": "(Organo de Control).\n1. El órgano de control deberá realizar todas las acciones necesarias para el cumplimiento de los objetivos y demás disposiciones de la presente ley. A tales efectos tendrá las siguientes funciones y atribuciones:\na) Asistir y asesorar a las personas que lo requieran acerca de los alcances de la presente y de los medios legales de que disponen para la defensa de los derechos que ésta garantiza;\nb) Dictar las normas y reglamentaciones que se deben observar en el desarrollo de las actividades comprendidas por esta ley;\nc) Realizar un censo de archivos, registros o bancos de datos alcanzados por la ley y mantener el registro permanente de los mismos;\nd) Controlar la observancia de las normas sobre integridad y seguridad de datos por parte de los archivos, registros o bancos de datos. A tal efecto podrá solicitar autorización judicial para acceder a locales, equipos, o programas de tratamiento de datos a fin de verificar infracciones al cumplimiento de la presente ley;\ne) Solicitar información a las entidades públicas y privadas, las que deberán proporcionar los antecedentes, documentos, programas u otros elementos relativos al tratamiento de los datos personales que se le requieran. En estos casos, la autoridad deberá garantizar la seguridad y confidencialidad de la información y elementos suministrados;\nf) Imponer las sanciones administrativas que en su caso correspondan por violación a las normas de la presente ley y de las reglamentaciones que se dicten en su consecuencia;\ng) Constituirse en querellante en las acciones penales que se promovieran por violaciones a la presente ley;\nh) Controlar el cumplimiento de los requisitos y garantías que deben reunir los archivos o bancos de datos privados destinados a suministrar informes, para obtener la correspondiente inscripción en el Registro creado por esta ley.\n2. (Punto vetado por art. 1° del Decreto N° 995/2000 B.O. 2/11/2000)\n3. (Punto vetado por art. 1° del Decreto N° 995/2000 B.O. 2/11/2000)\nEl Director tendrá dedicación exclusiva en su función, encontrándose alcanzado por las incompatibilidades fijadas por ley para los funcionarios públicos y podrá ser removido por el Poder Ejecutivo por mal desempeño de sus funciones.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "30",
+      "text": "(Códigos de conducta).\n1. Las asociaciones o entidades representativas de responsables o usuarios de bancos de datos de titularidad privada podrán elaborar códigos de conducta de práctica profesional, que establezcan normas para el tratamiento de datos personales que tiendan a asegurar y mejorar las condiciones de operación de los sistemas de información en función de los principios establecidos en la presente ley.\n2. Dichos códigos deberán ser inscriptos en el registro que al efecto lleve el organismo de control, quien podrá denegar la inscripción cuando considere que no se ajustan a las disposiciones legales y reglamentarias sobre la materia.\nCapítulo VI\nSanciones",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "31",
+      "text": "(Sanciones administrativas).\n1. Sin perjuicio de las responsabilidades administrativas que correspondan en los casos de responsables o usuarios de bancos de datos públicos; de la responsabilidad por daños y perjuicios derivados de la inobservancia de la presente ley, y de las sanciones penales que correspondan, el organismo de control podrá aplicar las sanciones de apercibimiento, suspensión, multa de mil pesos ($ 1.000.-) a cien mil pesos ($ 100.000.-), clausura o cancelación del archivo, registro o banco de datos.\n2. La reglamentación determinará las condiciones y procedimientos para la aplicación de las sanciones previstas, las que deberán graduarse en relación a la gravedad y extensión de la violación y de los perjuicios derivados de la infracción, garantizando el principio del debido proceso.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "32",
+      "text": "(Sanciones penales).\n1. Incorpórase como artículo 117 bis del Código Penal, el siguiente:\n\"1°. Será reprimido con la pena de prisión de un mes a dos años el que insertara o hiciera insertar a sabiendas datos falsos en un archivo de datos personales.\n2°. La pena será de seis meses a tres años, al que proporcionara a un tercero a sabiendas información falsa contenida en un archivo de datos personales.\n3°. La escala penal se aumentará en la mitad del mínimo y del máximo, cuando del hecho se derive perjuicio a alguna persona.\n4°. Cuando el autor o responsable del ilícito sea funcionario público en ejercicio de sus funciones, se le aplicará la accesoria de inhabilitación para el desempeño de cargos públicos por el doble del tiempo que el de la condena\".\n2. Incorpórase como artículo 157 bis del Código Penal el siguiente:\n\"Será reprimido con la pena de prisión de un mes a dos años el que:\n1°. A sabiendas e ilegítimamente, o violando sistemas de confidencialidad y seguridad de datos, accediere, de cualquier forma, a un banco de datos personales;\n2°. Revelare a otro información registrada en un banco de datos personales cuyo secreto estuviere obligado a preservar por disposición de una ley. \nCuando el autor sea funcionario público sufrirá, además, pena de inhabilitación especial de uno a cuatro años\".\nCapítulo VII\nAcción de protección de los datos personales",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "33",
+      "text": "(Procedencia).\n1. La acción de protección de los datos personales o de hábeas data procederá:\na) para tomar conocimiento de los datos personales almacenados en archivos, registros o bancos de datos públicos o privados destinados a proporcionar informes, y de la finalidad de aquéllos;\nb) en los casos en que se presuma la falsedad, inexactitud, desactualización de la información de que se trata, o el tratamiento de datos cuyo registro se encuentra prohibido en la presente ley, para exigir su rectificación, supresión, confidencialidad o actualización.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "34",
+      "text": "(Legitimación activa).\nLa acción de protección de los datos personales o de hábeas data podrá ser ejercida por el afectado, sus tutores o curadores y los sucesores de las personas físicas, sean en línea directa o colateral hasta el segundo grado, por sí o por intermedio de apoderado.\nCuando la acción sea ejercida por personas de existencia ideal, deberá ser interpuesta por sus representantes legales, o apoderados que éstas designen al efecto.\nEn el proceso podrá intervenir en forma coadyuvante el Defensor del Pueblo.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "35",
+      "text": "(Legitimación pasiva).\nLa acción procederá respecto de los responsables y usuarios de bancos de datos públicos, y de los privados destinados a proveer informes.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "36",
+      "text": "(Competencia).\nSerá competente para entender en esta acción el juez del domicilio del actor; el del domicilio del demandado; el del lugar en el que el hecho o acto se exteriorice o pudiera tener efecto, a elección del actor.\nProcederá la competencia federal:\na) cuando se interponga en contra de archivos de datos públicos de organismos nacionales, y\nb) cuando los archivos de datos se encuentren interconectados en redes interjurisdicciones, nacionales o internacionales.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "37",
+      "text": "(Procedimiento aplicable).\nLa acción de hábeas data tramitará según las disposiciones de la presente ley y por el procedimiento que corresponde a la acción de amparo común y supletoriamente por las normas del Código Procesal Civil y Comercial de la Nación, en lo atinente al juicio sumarísimo.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "38",
+      "text": "(Requisitos de la demanda).\n1. La demanda deberá interponerse por escrito, individualizando con la mayor precisión posible el nombre y domicilio del archivo, registro o banco de datos y, en su caso, el nombre del responsable o usuario del mismo.\nEn el caso de los archivos, registros o bancos públicos, se procurará establecer el organismo estatal del cual dependen.\n2. El accionante deberá alegar las razones por las cuales entiende que en el archivo, registro o banco de datos individualizado obra información referida a su persona; los motivos por los cuales considera que la información que le atañe resulta discriminatoria, falsa o inexacta y justificar que se han cumplido los recaudos que hacen al ejercicio de los derechos que le reconoce la presente ley.\n3. El afectado podrá solicitar que mientras dure el procedimiento, el registro o banco de datos asiente que la información cuestionada está sometida a un proceso judicial.\n4. El Juez podrá disponer el bloqueo provisional del archivo en lo referente al dato personal motivo del juicio cuando sea manifiesto el carácter discriminatorio, falso o inexacto de la información de que se trate.\n5. A los efectos de requerir información al archivo, registro o banco de datos involucrado, el criterio judicial de apreciación de las circunstancias requeridas en los puntos 1 y 2 debe ser amplio.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "39",
+      "text": "(Trámite).\n1. Admitida la acción el juez requerirá al archivo, registro o banco de datos la remisión de la información concerniente al accionante. Podrá asimismo solicitar informes sobre el soporte técnico de datos, documentación de base relativa a la recolección y cualquier otro aspecto que resulte conducente a la resolución de la causa que estime procedente.\n2. El plazo para contestar el informe no podrá ser mayor de cinco días hábiles, el que podrá ser ampliado prudencialmente por el juez.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "40",
+      "text": "(Confidencialidad de la información).\n1. Los registros, archivos o bancos de datos privados no podrán alegar la confidencialidad de la información que se les requiere salvo el caso en que se afecten las fuentes de información periodística. \n2. Cuando un archivo, registro o banco de datos público se oponga a la remisión del informe solicitado con invocación de las excepciones al derecho de acceso, rectificación o supresión, autorizadas por la presente ley o por una ley específica; deberá acreditar los extremos que hacen aplicable la excepción legal. En tales casos, el juez podrá tomar conocimiento personal y directo de los datos solicitados asegurando el mantenimiento de su confidencialidad.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "41",
+      "text": "(Contestación del informe).\nAl contestar el informe, el archivo, registro o banco de datos deberá expresar las razones por las cuales incluyó la información cuestionada y aquellas por las que no evacuó el pedido efectuado por el interesado, de conformidad a lo establecido en los artículos 13 a 15 de la ley.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "42",
+      "text": "(Ampliación de la demanda).\nContestado el informe, el actor podrá, en el término de tres días, ampliar el objeto de la demanda solicitando la supresión, rectificación, confidencialidad o actualización de sus datos personales, en los casos que resulte procedente a tenor de la presente ley, ofreciendo en el mismo acto la prueba pertinente. De esta presentación se dará traslado al demandado por el término de tres días.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "43",
+      "text": "(Sentencia).\n1. Vencido el plazo para la contestación del informe o contestado el mismo, y en el supuesto del artículo 42, luego de contestada la ampliación, y habiendo sido producida en su caso la prueba, el juez dictará sentencia.\n2. En el caso de estimarse procedente la acción, se especificará si la información debe ser suprimida, rectificada, actualizada o declarada confidencial, estableciendo un plazo para su cumplimiento.\n3. El rechazo de la acción no constituye presunción respecto de la responsabilidad en que hubiera podido incurrir el demandante.\n4. En cualquier caso, la sentencia deberá ser comunicada al organismo de control, que deberá llevar un registro al efecto.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "44",
+      "text": "(Ambito de aplicación).\nLas normas de la presente ley contenidas en los Capítulos I, II, III y IV, y artículo 32 son de orden público y de aplicación en lo pertinente en todo el territorio nacional.\nSe invita a las provincias a adherir a las normas de esta ley que fueren de aplicación exclusiva en jurisdicción nacional.\nLa jurisdicción federal regirá respecto de los registros, archivos, bases o bancos de datos interconectados en redes de alcance interjurisdiccional, nacional o internacional.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "45",
+      "text": "El Poder Ejecutivo Nacional deberá reglamentar la presente ley y establecer el organismo de control dentro de los ciento ochenta días de su promulgación.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "46",
+      "text": "(Disposiciones transitorias).\nLos archivos, registros, bases o bancos de datos destinados a proporcionar informes, existentes al momento de la sanción de la presente ley, deberán inscribirse en el registro que se habilite conforme a lo dispuesto en el artículo 21 y adecuarse a lo que dispone el presente régimen dentro del plazo que al efecto establezca la reglamentación.\n(Nota Infoleg: por art. 2° del Decreto N° 1558/2001 B.O. 3/12/2001 se establece en CIENTO OCHENTA (180) días el plazo previsto en el presente artículo)",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "47",
+      "text": "Los bancos de datos destinados a prestar servicios de información crediticia deberán eliminar y omitir el asiento en el futuro de todo dato referido a obligaciones y calificaciones asociadas de las personas físicas y jurídicas cuyas obligaciones comerciales se hubieran constituido en mora, o cuyas obligaciones financieras hubieran sido clasificadas con categoría 2, 3, 4 ó 5, según normativas del Banco Central de la República Argentina, en ambos casos durante el período comprendido entre el 1º de enero del año 2000 y el 10 de diciembre de 2003, siempre y cuando esas deudas hubieran sido canceladas o regularizadas al momento de entrada en vigencia de la presente ley o lo sean dentro de los 180 días posteriores a la misma. La suscripción de un plan de pagos por parte del deudor, o la homologación del acuerdo preventivo o del acuerdo preventivo extrajudicial importará la regularización de la deuda, a los fines de esta ley.\nEl Banco Central de la República Argentina establecerá los mecanismos que deben cumplir las Entidades Financieras para informar a dicho organismo los datos necesarios para la determinación de los casos encuadrados. Una vez obtenida dicha información, el Banco Central de la República Argentina implementará las medidas necesarias para asegurar que todos aquellos que consultan los datos de su Central de Deudores sean informados de la procedencia e implicancias de lo aquí dispuesto.\nToda persona que considerase que sus obligaciones canceladas o regularizadas están incluidas en lo prescripto en el presente artículo puede hacer uso de los derechos de acceso, rectificación y actualización en relación con lo establecido.\nSin perjuicio de lo expuesto en los párrafos precedentes, el acreedor debe comunicar a todo archivo, registro o banco de datos al que hubiera cedido datos referentes al incumplimiento de la obligación original, su cancelación o regularización.\n(Artículo incorporado por art. 1° de la Ley N° 26.343 B.O. 9/1/2008)",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    },
+    {
+      "number": "48",
+      "text": "Comuníquese al Poder Ejecutivo. \nDADA EN LA SALA DE SESIONES DEL CONGRESO ARGENTINO, EN BUENOS AIRES, A LOS CUATRO DIAS DEL MES DE OCTUBRE DEL AÑO DOS MIL.\n— REGISTRADO BAJO EL N° 25.326 —\nRAFAEL PASCUAL. — JOSE GENOUD. — Guillermo Aramburu. — Mario L. Pontaquarto.",
+      "incisos": [],
+      "location": {},
+      "materia": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argleg-mcp",
-  "version": "0.1.41",
+  "version": "0.1.47",
   "private": true,
   "description": "MCP server for Argentine legislation (read-only, local source of truth).",
   "type": "module",

--- a/src/laws/types.ts
+++ b/src/laws/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const LawIdSchema = z
-  .enum(["constitucion", "ccyc", "penal", "cppf", "cpccn", "ley_24240", "ley_19550", "ley_19549"])
+  .enum(["constitucion", "ccyc", "penal", "cppf", "cpccn", "ley_24240", "ley_19550", "ley_19549", "ley_25326"])
   .describe("Identificador canónico de la norma.");
 
 export type LawId = z.infer<typeof LawIdSchema>;
@@ -57,6 +57,7 @@ export const LAW_IDS: LawId[] = [
   "ley_24240",
   "ley_19550",
   "ley_19549",
+  "ley_25326",
 ];
 
 export const LAW_FILE_BY_ID: Record<LawId, string> = {
@@ -68,4 +69,5 @@ export const LAW_FILE_BY_ID: Record<LawId, string> = {
   ley_24240: "ley_24240.json",
   ley_19550: "ley_19550.json",
   ley_19549: "ley_19549.json",
+  ley_25326: "ley_25326.json",
 };

--- a/src/scripts/fetch-infoleg.ts
+++ b/src/scripts/fetch-infoleg.ts
@@ -59,6 +59,11 @@ const DEFAULT_TITLES: Record<string, { title: string; shortName: string; officia
     shortName: "LNPA",
     officialNumber: "Ley 19.549",
   },
+  ley_25326: {
+    title: "Ley de Protección de los Datos Personales",
+    shortName: "LPDP",
+    officialNumber: "Ley 25.326",
+  },
 };
 
 function usage(): void {
@@ -156,7 +161,11 @@ async function readHtml(args: Args): Promise<{ html: string; source: string }> {
     const buf = await readFile(abs);
     let html = buf.toString("utf8");
     if (looksMojibake(html)) {
-      html = buf.toString("latin1");
+      // InfoLEG actually serves CP1252 (Windows-1252), not strict ISO-8859-1.
+      // Bytes 0x80-0x9F encode typographic chars (— – ' " … etc.) in CP1252 but
+      // map to invisible control chars in Latin-1. Node's TextDecoder("windows-1252")
+      // leaves these bytes as U+0080-U+009F, so we remap them manually.
+      html = decodeCp1252(buf);
     }
     return { html, source: abs };
   }
@@ -165,7 +174,7 @@ async function readHtml(args: Args): Promise<{ html: string; source: string }> {
     const res = await fetch(args.url, {
       headers: {
         "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "es-AR,es;q=0.9,en;q=0.8",
         "Referer": "https://www.infoleg.gob.ar/",
@@ -176,11 +185,40 @@ async function readHtml(args: Args): Promise<{ html: string; source: string }> {
     // InfoLEG sometimes serves ISO-8859-1. Try UTF-8 first; fall back on replacement chars.
     let html = buf.toString("utf8");
     if (looksMojibake(html)) {
-      html = buf.toString("latin1");
+      // InfoLEG actually serves CP1252 (Windows-1252), not strict ISO-8859-1.
+      // Bytes 0x80-0x9F encode typographic chars (— – ' " … etc.) in CP1252 but
+      // map to invisible control chars in Latin-1. Node's TextDecoder("windows-1252")
+      // leaves these bytes as U+0080-U+009F, so we remap them manually.
+      html = decodeCp1252(buf);
     }
     return { html, source: args.url };
   }
   throw new Error("Falta --url o --file");
+}
+
+/**
+ * Decode a Buffer as Windows-1252. Node's TextDecoder("windows-1252") has a
+ * known limitation where it leaves bytes 0x80-0x9F as the matching Unicode
+ * code point instead of mapping them to the typographic chars defined by the
+ * CP1252 spec. We start from latin1 and remap the affected range manually.
+ */
+function decodeCp1252(buf: Buffer): string {
+  const CP1252_HIGH: Record<number, string> = {
+    0x80: "€", 0x82: "‚", 0x83: "ƒ", 0x84: "„", 0x85: "…", 0x86: "†",
+    0x87: "‡", 0x88: "ˆ", 0x89: "‰", 0x8a: "Š", 0x8b: "‹", 0x8c: "Œ",
+    0x8e: "Ž", 0x91: "'", 0x92: "'", 0x93: "“", 0x94: "”",
+    0x95: "•", 0x96: "–", 0x97: "—", 0x98: "˜", 0x99: "™", 0x9a: "š",
+    0x9b: "›", 0x9c: "œ", 0x9e: "ž", 0x9f: "Ÿ",
+  };
+  let out = "";
+  for (const b of buf) {
+    if (b >= 0x80 && b <= 0x9f && CP1252_HIGH[b]) {
+      out += CP1252_HIGH[b];
+    } else {
+      out += String.fromCharCode(b);
+    }
+  }
+  return out;
 }
 
 function looksMojibake(s: string): boolean {

--- a/src/scripts/parsers/index.ts
+++ b/src/scripts/parsers/index.ts
@@ -8,6 +8,7 @@ import { parsePenal } from "./penal.js";
 import { parseGeneric } from "./generic.js";
 import { parseLey19549 } from "./ley_19549.js";
 import { parseLey19550 } from "./ley_19550.js";
+import { parseLey25326 } from "./ley_25326.js";
 
 export function parseLawHtml(id: LawId, html: string): Article[] {
   switch (id) {
@@ -27,6 +28,8 @@ export function parseLawHtml(id: LawId, html: string): Article[] {
       return parseLey19549(html);
     case "ley_19550":
       return parseLey19550(html);
+    case "ley_25326":
+      return parseLey25326(html);
     default: {
       const exhaustive: never = id;
       return exhaustive;

--- a/src/scripts/parsers/ley_25326.ts
+++ b/src/scripts/parsers/ley_25326.ts
@@ -1,0 +1,45 @@
+import type { Article } from "../../laws/types.js";
+import { htmlToText, truncateAtMarkers } from "./base.js";
+
+const FOOTERS = [/^\s*Antecedentes\s+Normativos\b/im];
+// In InfoLEG's rendering of Ley 25.326 articles begin in two slightly different
+// shapes depending on the article number:
+//   "ARTICULO 9° — (Título)."   (ordinal degree + em dash)
+//   "ARTICULO 10. — (Título)."  (period + em dash)
+// We allow any mix of whitespace and separators between the number and the
+// start of the title (which is either a parenthetical or capitalised text).
+const ARTICLE_RE =
+  /^\s*ART[IÍ]CULO\s+(\d+\s*[°º]?\s*(?:bis|ter|quater|quinquies|sexies)?|\d+)[\s\-–—:.]+(?=\(|[A-ZÁÉÍÓÚ])/gimu;
+
+export function parseLey25326(html: string): Article[] {
+  let text = htmlToText(html);
+  const first = /ART[IÍ]CULO\s+1\s*[°º]?[\s\-–—:.]+\(/iu.exec(text);
+  if (!first) return [];
+  text = text.slice(first.index);
+  text = truncateAtMarkers(text, FOOTERS);
+
+  const matches: Array<{ number: string; start: number; end: number }> = [];
+  let m: RegExpExecArray | null;
+  const re = new RegExp(ARTICLE_RE.source, ARTICLE_RE.flags);
+  while ((m = re.exec(text)) !== null) {
+    const number = (m[1] ?? "").replace(/°|º/g, "").replace(/\s+/g, "").toLowerCase();
+    if (!number) continue;
+    matches.push({ number, start: m.index, end: re.lastIndex });
+  }
+
+  const out: Article[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < matches.length; i++) {
+    const cur = matches[i]!;
+    const next = matches[i + 1];
+    let body = text.slice(cur.end, next ? next.start : text.length).trim();
+    body = body
+      .replace(/\n\s*TITULO\s+[A-ZÁÉÍÓÚ0-9]+.*$/imu, "")
+      .replace(/\n\s*CAPITULO\s+[A-ZÁÉÍÓÚ0-9]+.*$/imu, "")
+      .trim();
+    if (!body || seen.has(cur.number)) continue;
+    seen.add(cur.number);
+    out.push({ number: cur.number, text: body, incisos: [], location: {}, materia: [] });
+  }
+  return out;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const ARGLEG_VERSION = "0.1.41";
-export const ARGLEG_BUILD_DATE_TIME = "2026-04-25T02:48:51.949Z";
+export const ARGLEG_VERSION = "0.1.47";
+export const ARGLEG_BUILD_DATE_TIME = "2026-05-01T20:34:55.065Z";


### PR DESCRIPTION
- New parser src/scripts/parsers/ley_25326.ts handling InfoLEG's "ARTICULO N° — (Título)" and "ARTICULO N. — (Título)" variants.
- Register ley_25326 in LawIdSchema, LAW_IDS, LAW_FILE_BY_ID and the parser dispatch switch.
- fetch-infoleg.ts: switch UA to Firefox (InfoLEG started returning HTTP 403 to the Chrome UA) and add manual CP1252 decoder to fix the typographic chars (— – etc.) that Node's TextDecoder leaves as U+0080-U+009F.
- Source HTML kept under data/25326/ as fixture for re-parsing.