### PR TITLE
feat: tag every log line with the connecting MCP client identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,8 @@ Levels:
 - `verbose` — adds `rpc.request`, `tool.call`, `tool.done`, `resource.read`, `resource.done`, `prompt.call`.
 - `debug` — adds `rpc.notification`, plus args/params/result-size payloads on the handler-layer events.
 
+**Client identity tagging.** When the connecting MCP client sends `clientInfo` in the `initialize` handshake (Claude Desktop, Claude Code, Cursor, etc. all do), `logRpcMessage` extracts `{ name, version }` and stores it via `setClientInfo()` in `src/log.ts`. From that point on **every** log line — pretty or JSON — gets a `client={"name":"…","version":"…"}` field automatically merged in by `withClient()`. This lets you grep `tool.call` lines by client. The stdio transport is 1:1 client↔process, so the module-level slot is safe; if HTTP/SSE multi-client is ever added, the identity will need to move into per-request context. The `client` field is omitted when both name and version are unset (e.g., before `initialize` is observed).
+
 Output goes to **stderr** by default. Set `ARGLEG_LOG_FILE=/path/to/file.log` to mirror everything to a file (useful when the MCP server is launched by Claude Desktop, which discards the child process's stderr — `tail -f` the file in another terminal to see live traffic).
 
 ## Environment variables

--- a/docs/guia.md
+++ b/docs/guia.md
@@ -323,6 +323,8 @@ Hay tres capas de eventos:
 2. **Handlers** (`tool.call`, `tool.done`, `tool.error`, `resource.*`, `prompt.*`) — cada invocación de tool/resource/prompt, con timing.
 3. **Lifecycle** (`server.loading`, `server.norma_loaded`, `server.ready`, `server.started`, `server.fatal`).
 
+Cada línea emitida **después** del handshake `initialize` también lleva un campo `client={"name":"…","version":"…"}`, tomado del bloque `clientInfo` que envía el cliente MCP. Esto permite saber qué cliente (Claude Desktop, Claude Code, Cursor, …) hizo cada llamada al grepear los logs.
+
 ```bash
 # Ver cada request entrante + cada llamada a tool
 ARGLEG_LOG_LEVEL=verbose npm start
@@ -332,6 +334,9 @@ ARGLEG_LOG_LEVEL=debug npm start
 
 # Logs en formato JSON, guardados en archivo
 ARGLEG_LOG_LEVEL=debug ARGLEG_LOG_JSON=1 ARGLEG_LOG_FILE=/tmp/argleg.jsonl npm start
+
+# Filtrar solo las llamadas hechas por Claude Code
+ARGLEG_LOG_LEVEL=verbose ARGLEG_LOG_JSON=1 npm start 2>&1 | jq 'select(.client.name == "claude-code")'
 ```
 
 > Si lanzás el servidor desde Claude Desktop, su stderr queda capturado por el cliente. Para ver los logs en vivo, usá `ARGLEG_LOG_FILE=/tmp/argleg-mcp.log` y en otra terminal corré `tail -f /tmp/argleg-mcp.log`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -318,6 +318,8 @@ Three layers of events are emitted:
 2. **Handler layer** (`tool.call`, `tool.done`, `tool.error`, `resource.*`, `prompt.*`) — every tool/resource/prompt invocation, with timing.
 3. **Lifecycle** (`server.loading`, `server.norma_loaded`, `server.ready`, `server.started`, `server.fatal`).
 
+Every log line emitted **after** the `initialize` handshake also carries a `client={"name":"…","version":"…"}` field, populated from the `clientInfo` block the MCP client sends. This lets you tell which client (Claude Desktop, Claude Code, Cursor, …) made each call when grepping logs.
+
 ```bash
 # Live request tracing + tool calls
 ARGLEG_LOG_LEVEL=verbose npm start
@@ -327,6 +329,9 @@ ARGLEG_LOG_LEVEL=debug npm start
 
 # JSON logs saved to file
 ARGLEG_LOG_LEVEL=debug ARGLEG_LOG_JSON=1 ARGLEG_LOG_FILE=/tmp/argleg.jsonl npm start
+
+# Filter all calls made by Claude Code only
+ARGLEG_LOG_LEVEL=verbose ARGLEG_LOG_JSON=1 npm start 2>&1 | jq 'select(.client.name == "claude-code")'
 ```
 
 > When the server runs as a child of Claude Desktop, that client captures stderr. Set `ARGLEG_LOG_FILE=/tmp/argleg-mcp.log` and `tail -f` it from another terminal to see live traffic.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argleg-mcp",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "description": "MCP server for Argentine legislation (read-only, local source of truth).",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { buildServer } from "./server.js";
-import { log, truncate } from "./log.js";
+import { log, setClientInfo, truncate } from "./log.js";
 
 /**
  * Logs every inbound JSON-RPC message at the transport layer, before the SDK
@@ -19,6 +19,12 @@ function logRpcMessage(message: JSONRPCMessage): void {
   const method = (message as { method: string }).method;
   const isRequest = "id" in message && (message as { id?: unknown }).id !== undefined;
   const params = (message as { params?: unknown }).params;
+  // Capture client identity from the `initialize` handshake so every
+  // subsequent log line (including this one) is tagged with `client=…`.
+  if (method === "initialize" && params && typeof params === "object") {
+    const ci = (params as { clientInfo?: { name?: string; version?: string } }).clientInfo;
+    if (ci) setClientInfo({ name: ci.name, version: ci.version });
+  }
   if (isRequest) {
     log.verbose("rpc.request", {
       method,

--- a/src/log.ts
+++ b/src/log.ts
@@ -37,6 +37,34 @@ const LEVEL: LogLevel = resolveLevel();
 const JSON_MODE = process.env.ARGLEG_LOG_JSON === "1";
 const LOG_FILE = process.env.ARGLEG_LOG_FILE?.trim() || "";
 
+/**
+ * Identity of the connected MCP client, populated from the `clientInfo` field
+ * of the `initialize` JSON-RPC handshake. Auto-merged into every log line so
+ * tool/resource calls can be attributed to a specific client (Claude Desktop,
+ * Claude Code, Cursor, etc.). The stdio transport is 1:1 client↔process, so
+ * a module-level slot is safe.
+ */
+export interface ClientInfo {
+  name?: string;
+  version?: string;
+}
+let CLIENT_INFO: ClientInfo | undefined;
+
+export function setClientInfo(info: ClientInfo): void {
+  CLIENT_INFO = info;
+}
+
+export function getClientInfo(): ClientInfo | undefined {
+  return CLIENT_INFO;
+}
+
+function withClient(fields: Record<string, unknown>): Record<string, unknown> {
+  if (!CLIENT_INFO) return fields;
+  // Skip the tag if both name and version are absent — avoids printing `client={}`.
+  if (CLIENT_INFO.name === undefined && CLIENT_INFO.version === undefined) return fields;
+  return { client: CLIENT_INFO, ...fields };
+}
+
 function enabled(at: LogLevel): boolean {
   return LEVEL_RANK[at] <= LEVEL_RANK[LEVEL];
 }
@@ -54,12 +82,13 @@ function writeLine(line: string): void {
 function emit(level: LogLevel, event: string, fields: Record<string, unknown> = {}): void {
   if (!enabled(level)) return;
   const ts = new Date().toISOString();
+  const merged = withClient(fields);
   if (JSON_MODE) {
-    const line = JSON.stringify({ ts, level, event, ...fields }) + "\n";
+    const line = JSON.stringify({ ts, level, event, ...merged }) + "\n";
     writeLine(line);
     return;
   }
-  const pairs = Object.entries(fields)
+  const pairs = Object.entries(merged)
     .filter(([, v]) => v !== undefined)
     .map(([k, v]) => `${k}=${fmt(v)}`)
     .join(" ");
@@ -95,11 +124,12 @@ export const log = {
     // Errors are always shown unless silent.
     if (LEVEL === "silent") return;
     const ts = new Date().toISOString();
+    const merged = withClient(fields ?? {});
     if (JSON_MODE) {
-      writeLine(JSON.stringify({ ts, level: "error", event, ...fields }) + "\n");
+      writeLine(JSON.stringify({ ts, level: "error", event, ...merged }) + "\n");
       return;
     }
-    const pairs = Object.entries(fields ?? {})
+    const pairs = Object.entries(merged)
       .filter(([, v]) => v !== undefined)
       .map(([k, v]) => `${k}=${fmt(v)}`)
       .join(" ");

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const ARGLEG_VERSION = "0.1.57";
-export const ARGLEG_BUILD_DATE_TIME = "2026-05-02T03:59:59.025Z";
+export const ARGLEG_VERSION = "0.1.58";
+export const ARGLEG_BUILD_DATE_TIME = "2026-05-02T05:18:28.094Z";

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { log, setClientInfo, getClientInfo } from "../src/log.js";
+
+function captureStderr(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    lines.push(String(chunk));
+    return true;
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+afterEach(() => {
+  // Reset module-level client identity between tests to avoid bleed.
+  setClientInfo({ name: undefined, version: undefined });
+});
+
+describe("setClientInfo / log client tagging", () => {
+  it("does not tag log lines before initialize is observed", () => {
+    setClientInfo({ name: undefined, version: undefined });
+    const { lines, restore } = captureStderr();
+    try {
+      log.info("test.event", { x: 1 });
+    } finally {
+      restore();
+    }
+    const all = lines.join("");
+    expect(all).toContain("test.event");
+    expect(all).not.toContain("client=");
+  });
+
+  it("tags every subsequent log line with client name and version", () => {
+    setClientInfo({ name: "claude-ai", version: "0.7.0" });
+    const { lines, restore } = captureStderr();
+    try {
+      log.info("tool.call", { name: "search_articles" });
+    } finally {
+      restore();
+    }
+    const line = lines.join("");
+    expect(line).toContain("tool.call");
+    expect(line).toContain("client=");
+    expect(line).toContain("claude-ai");
+    expect(line).toContain("0.7.0");
+    expect(line).toContain("name=search_articles");
+  });
+
+  it("tags error lines too", () => {
+    setClientInfo({ name: "cursor", version: "1.2.3" });
+    const { lines, restore } = captureStderr();
+    try {
+      log.error("tool.error", { name: "search_articles", error: "boom" });
+    } finally {
+      restore();
+    }
+    const line = lines.join("");
+    expect(line).toContain("tool.error");
+    expect(line).toContain("client=");
+    expect(line).toContain("cursor");
+    expect(line).toContain("1.2.3");
+  });
+
+  it("getClientInfo returns the last value set", () => {
+    setClientInfo({ name: "claude-code", version: "2.0" });
+    expect(getClientInfo()).toEqual({ name: "claude-code", version: "2.0" });
+  });
+});


### PR DESCRIPTION
Today there is no way to tell from the logs which MCP client (Claude Desktop, Claude Code, Cursor, …) made a given call. The `clientInfo` sent in the `initialize` handshake gets dropped on the floor.

This change captures `clientInfo.{name,version}` from the `initialize` JSON-RPC request inside `logRpcMessage` and stores it via a new `setClientInfo()` slot in `src/log.ts`. From that point on, every log line — `rpc.request`, `tool.call`, `tool.done`, `resource.*`, errors — gets a `client={"name":"…","version":"…"}` field auto-merged into its output (both pretty and JSONL modes), so calls can be attributed to the originating client when grepping logs or piping into `jq`.

The stdio transport is 1:1 client↔process, so a module-level slot is safe; if HTTP/SSE multi-client transport is added later, the identity will need to move into per-request context.

Also updates CLAUDE.md, docs/guide.md and docs/guia.md to document the new tag and includes a `jq` filtering example.