### PR TITLE
fix(ingest): collapse InfoLEG soft-wrap newlines in article text (bug #6)

### DIFF
--- a/src/scripts/db-import.ts
+++ b/src/scripts/db-import.ts
@@ -13,7 +13,7 @@ import {
   trimTrailingOrphans,
   type DetectedHeader,
 } from "./parsers/structural-headers.js";
-import { extractTrailingEpigraphs } from "./parsers/base.js";
+import { collapseWrappedLines, extractTrailingEpigraphs } from "./parsers/base.js";
 
 /**
  * Vigencia curada para las normas foundational del corpus.
@@ -155,7 +155,7 @@ function slugify(s: string): string {
 }
 
 function articleTextWithIncisos(article: Article, cleanText?: string): string {
-  const body = (cleanText ?? article.text).trimEnd();
+  const body = collapseWrappedLines((cleanText ?? article.text).trimEnd());
   if (article.incisos.length === 0) return body;
   const lines: string[] = [body];
   for (const inc of article.incisos) {
@@ -165,7 +165,7 @@ function articleTextWithIncisos(article: Article, cleanText?: string): string {
     // DEMANDADO" / "COMPROBACIONES DIRECTAS" inside the last inciso).
     const cleanedInc: Inciso = {
       id: inc.id,
-      text: trimTrailingOrphans(inc.text),
+      text: collapseWrappedLines(trimTrailingOrphans(inc.text)),
     };
     lines.push(formatIncisoForStorage(cleanedInc));
   }

--- a/src/scripts/parsers/base.ts
+++ b/src/scripts/parsers/base.ts
@@ -97,6 +97,27 @@ function cleanStructureValue(value?: string): string | undefined {
 }
 
 /**
+ * Collapse soft-wrap newlines from InfoLEG's HTML line-wrapping (~70 chars/line)
+ * into single spaces while preserving genuine paragraph breaks (double newlines).
+ *
+ * InfoLEG serves HTML where every visual line ends with a `<br>` tag. `htmlToText`
+ * converts those to `\n`, which makes article text look like:
+ *   "El trabajo en sus\ndiversas formas gozará..."
+ * instead of the correct single-paragraph sentence.
+ *
+ * Algorithm: split on `\n\n+` (paragraph boundaries), collapse remaining `\n`
+ * to space within each segment, normalise runs of spaces, trim each paragraph,
+ * and rejoin with `\n\n`.  Idempotent: already-clean text is left unchanged.
+ */
+export function collapseWrappedLines(text: string): string {
+  return text
+    .split(/\n{2,}/)
+    .map((para) => para.replace(/\n/g, " ").replace(/ {2,}/g, " ").trim())
+    .filter((para) => para.length > 0)
+    .join("\n\n");
+}
+
+/**
  * Strip InfoLEG-style trailing epigraphs from article bodies.
  *
  * In InfoLEG HTML the descriptive title (epigraph) of article N+1 appears

--- a/tests/parsers.test.ts
+++ b/tests/parsers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { extractArticlesForLaw } from "../src/scripts/infoleg.js";
-import { extractTrailingEpigraphs } from "../src/scripts/parsers/base.js";
+import { collapseWrappedLines, extractTrailingEpigraphs } from "../src/scripts/parsers/base.js";
 import type { Article } from "../src/laws/types.js";
 
 function makeArticle(number: string, text: string, title?: string): Article {
@@ -267,5 +267,45 @@ describe("extractTrailingEpigraphs", () => {
     expect(arts[0]!.number).toBe("27");
     expect(arts[0]!.text).not.toContain("Socios herederos");
     expect(arts[1]!.title).toBe("Socios herederos menores, incapaces o con capacidad restringida");
+  });
+});
+
+describe("collapseWrappedLines", () => {
+  it("collapses a soft-wrap single newline to space", () => {
+    expect(collapseWrappedLines("El trabajo en sus\ndiversas formas gozará")).toBe(
+      "El trabajo en sus diversas formas gozará",
+    );
+  });
+
+  it("preserves double newlines as paragraph breaks", () => {
+    const input = "Primer párrafo.\n\nSegundo párrafo.";
+    expect(collapseWrappedLines(input)).toBe(input);
+  });
+
+  it("normalizes each paragraph independently", () => {
+    const input = "Primera línea\ncontinuación.\n\nOtra línea\nmás texto.";
+    expect(collapseWrappedLines(input)).toBe("Primera línea continuación.\n\nOtra línea más texto.");
+  });
+
+  it("collapses three or more consecutive newlines to a single paragraph break", () => {
+    expect(collapseWrappedLines("A.\n\n\n\nB.")).toBe("A.\n\nB.");
+  });
+
+  it("normalises runs of spaces produced by the join", () => {
+    // Trailing space before newline + leading space after collapse → double space
+    expect(collapseWrappedLines("Texto  con  espacios  extra.")).toBe("Texto con espacios extra.");
+  });
+
+  it("is idempotent — already clean text is unchanged", () => {
+    const clean = "Primer párrafo limpio.\n\nSegundo párrafo limpio.";
+    expect(collapseWrappedLines(clean)).toBe(clean);
+  });
+
+  it("trims leading and trailing whitespace within each paragraph", () => {
+    expect(collapseWrappedLines("  Texto con margen.  ")).toBe("Texto con margen.");
+  });
+
+  it("drops empty paragraphs", () => {
+    expect(collapseWrappedLines("A.\n\n\n\nB.")).toBe("A.\n\nB.");
   });
 });

--- a/tests/sections.test.ts
+++ b/tests/sections.test.ts
@@ -155,6 +155,40 @@ describe("structural recovery (bug #1 + tech debt #3)", () => {
     });
   });
 
+  describe("bug #6 — soft-wrap newlines collapsed in article text", () => {
+    it("CN art 14bis has exactly 3 paragraphs (\\n\\n separated) with no internal newlines", () => {
+      const result = repo.getArticle("constitucion", "14bis");
+      expect(result).toBeDefined();
+      const text = result!.articulo.texto;
+      const paras = text.split("\n\n");
+      expect(paras).toHaveLength(3);
+      for (const p of paras) {
+        expect(p).not.toContain("\n");
+      }
+    });
+
+    it("CN art 14bis paragraph 1 starts with 'El trabajo en sus diversas formas'", () => {
+      const result = repo.getArticle("constitucion", "14bis");
+      const text = result!.articulo.texto;
+      expect(text.startsWith("El trabajo en sus diversas formas")).toBe(true);
+    });
+
+    it("CCyC art 1 text contains no mid-sentence newlines", () => {
+      const result = repo.getArticle("ccyc", "1");
+      expect(result).toBeDefined();
+      const text = result!.articulo.texto;
+      // No single \n should exist outside of double-newline context
+      expect(text.replace(/\n\n/g, "")).not.toContain("\n");
+    });
+
+    it("LDC art 1 text contains no mid-sentence newlines", () => {
+      const result = repo.getArticle("ley_24240", "1");
+      expect(result).toBeDefined();
+      const text = result!.articulo.texto;
+      expect(text.replace(/\n\n/g, "")).not.toContain("\n");
+    });
+  });
+
   describe("bug #5 — Roman numeral title-casing (Iii / Xi / Viii)", () => {
     const BAD_ROMAN = /\b(Ii|Iii|Iv|Vi|Vii|Viii|Ix|Xi|Xii|Xiii|Xiv|Xv|Xvi|Xvii|Xviii|Xix|Xx)\b/;
 


### PR DESCRIPTION
## Summary

- **#6 [HIGH]** Article text preserved InfoLEG's HTML display line-breaks (~70 chars/line), splitting sentences mid-word: `"El trabajo en sus\ndiversas formas gozará..."`.

Added `collapseWrappedLines()` in `parsers/base.ts`: splits on `\n\n` (real paragraph breaks), collapses remaining `\n` to space within each segment, normalises extra spaces, rejoins with `\n\n`. Applied in `articleTextWithIncisos()` to both article body and each inciso text before DB insertion.

Golden test: CN art. 14bis now has exactly 3 clean paragraphs separated by `\n\n` with no internal newlines. First paragraph: `"El trabajo en sus diversas formas gozará..."`.

## Post-merge action required

\`\`\`bash
npm run db:reset
\`\`\`

## Test plan

- [x] `npm test` — 277 passed, 0 failed
- [x] `npm run typecheck` — clean
- [ ] `npm run db:reset` then verify `get_article(norma_id="constitucion", numero_articulo="14bis")` shows clean paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)